### PR TITLE
Login returns LoginResponse and LoginError objects

### DIFF
--- a/crates/login/Cargo.toml
+++ b/crates/login/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metaverse_login"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Skyler Clark<skylerjaneclark@gmail.com>"]
 description = "login utility for accessing the metaverse"
 edition = "2021"

--- a/crates/login/README.md
+++ b/crates/login/README.md
@@ -1,4 +1,4 @@
-Rust implementation of OpenSimulator's [login protocol](http://opensimulator.org/wiki/SimulatorLoginProtocol) 
+Rust implementation of OpenSimulator's [login protocol](http://opensimulator.org/wiki/SimulatorLoginProtocol)
 
 # Getting Started 
 ## Using Library 
@@ -6,15 +6,7 @@ Rust implementation of OpenSimulator's [login protocol](http://opensimulator.org
 ### [crate](https://crates.io/crates/metaverse_login)
 
 add 
-```
-metaverse_login = "0.0.0"
-```
-to your cargo.toml 
+```metaverse_login = "0.1.1"
 
-## Running Tests 
-to run the tests simply run cargo test 
-To run tests against live osgrid credentials, 
 ```
-cp .creds.example .creds.toml 
-```
-edit .creds.toml to include your username, password and login location.
+to your cargo.toml

--- a/crates/login/src/lib.rs
+++ b/crates/login/src/lib.rs
@@ -1,8 +1,7 @@
-//! # Rust implementation of OpenSimulator's [login protocol](http://opensimulator.org/wiki/SimulatorLoginProtocol)
-//!
-//! `metaverse_login` is a utility for running login commands against opensimulator or secondlife
-//! servers.
-
-///login functions for logging into metaverse servers
+///! # Rust implementation of OpenSimulator's [login protocol](http://opensimulator.org/wiki/SimulatorLoginProtocol)
+///!
+///! `metaverse_login` is a utility for running login commands against opensimulator or secondlife
+///! servers.
+////login functions for logging into metaverse servers
 pub mod login;
 pub mod models;

--- a/crates/login/src/models.rs
+++ b/crates/login/src/models.rs
@@ -1,2 +1,3 @@
+pub mod errors;
 pub mod login_response;
 pub mod simulator_login_protocol;

--- a/crates/login/src/models/errors.rs
+++ b/crates/login/src/models/errors.rs
@@ -1,0 +1,14 @@
+use std::error::Error;
+/// the type for the conversionerror, thrown when failing to convert a login response to a struct
+use std::fmt;
+
+#[derive(Debug)]
+pub struct ConversionError(pub &'static str);
+
+impl fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for ConversionError {}

--- a/crates/login/src/models/login_response.rs
+++ b/crates/login/src/models/login_response.rs
@@ -1,70 +1,119 @@
+use crate::models::errors::ConversionError;
+use std::error::Error;
 use std::fmt;
 use uuid::Uuid;
-use std::error::Error;
 
-pub enum LoginResult{
+/// This is the enum that the login function returns.
+/// This contains the response from the login request.
+/// can either be a LoginResponse, which is the successful login response,
+/// or it can be a LoginFailure, which is the a failure login response.
+pub enum LoginResult {
     Success(LoginResponse),
     Failure(LoginFailure),
 }
 
+/// This contains the information that the server returns upon a failed login request.
 pub struct LoginFailure {
     pub login: String,
     pub message: String,
     pub reason: String,
 }
 
-
+/// This is the full response struct of a successful opensimulator login.
+/// you can find more information about it at http://opensimulator.org/wiki/SimulatorLoginProtocol
+/// these types should be considered unstable until a 1.0.0 release of the login, due to the fact
+/// that I may realize some of thse are not optional.
 #[derive(Clone, Default, Debug)]
 pub struct LoginResponse {
-    pub home: Option<HomeValues>, // the home location of the user
-    pub look_at: Option<(String, String, String)>, // the direction the avatar should be facing
-    // This is a unit vector so
-    // (0, 1, 0) is facing straight north,
-    // (1, 0, 0) is east,
-    // (0,-1, 0) is south and
-    // (-1, 0, 0) is west.
-    pub agent_access: Option<AgentAccess>, // The current maturity access level of the user
-    pub agent_access_max: Option<AgentAccess>, // THe maximum level of region the user can access
-    pub seed_capability: Option<String>, // The URL that the viewer should use to request further capabilities
-    pub first_name: String,      // The first name of the user
-    pub last_name: String,       // The last name of the user
-    pub agent_id: Option<Uuid>,          // The id of the user
-    pub sim_ip: Option<String>,          // The ip used to communicate with the recieving simulator
-    pub sim_port: Option<u16>, // The UDP port used to communicate with the receiving simulator
-    pub http_port: Option<u16>, // function unknown. Always set to 0 by OpenSimulator
-    pub start_location: Option<String>, // The location where the user starts on login. "last", "home" or region location
-    pub region_x: Option<i64>,          //The x grid coordinate of the start region in meters.
-    // so a region at map co-ordinate 1000 will have a grid co-ordinate of 256000.
-    pub region_y: Option<i64>, // the y grid coordinate of the start region in meters
-    pub region_size_x: Option<i64>, // the size of the start region in meters.
-    // usually will be 236 but with a varregion this can be a multiple
-    // of 256
+    /// home: the home location of the user
+    pub home: Option<HomeValues>,
+    /// look_at: the direction the avatar should be facing
+    /// This is a unit vector so
+    /// (0, 1, 0) is facing straight north,
+    /// (1, 0, 0) is east,
+    /// (0,-1, 0) is south and
+    /// (-1, 0, 0) is west.
+    pub look_at: Option<(String, String, String)>,
+    /// agent_access: The current maturity access level of the user
+    pub agent_access: Option<AgentAccess>,
+    /// agent_access_max: The maximum level of region the user can access
+    pub agent_access_max: Option<AgentAccess>,
+    /// The URL that the viewer should use to request further capabilities
+    pub seed_capability: Option<String>,
+    /// The first name of the user
+    pub first_name: String,
+    /// The last name of the user
+    pub last_name: String,
+    /// The id of the user
+    pub agent_id: Option<Uuid>,
+    /// The ip used to communicate with the receiving simulator
+    pub sim_ip: Option<String>,
+    /// The UDP port used to communicate with the receiving simulator
+    pub sim_port: Option<u16>,
+    /// Function unknown. Always set to 0 by OpenSimulator
+    pub http_port: Option<u16>,
+    /// The location where the user starts on login. "last", "home" or region location
+    pub start_location: Option<String>,
+    /// The x grid coordinate of the start region in meters.
+    /// So a region at map coordinate 1000 will have a grid coordinate of 256000.
+    pub region_x: Option<i64>,
+    /// The y grid coordinate of the start region in meters
+    pub region_y: Option<i64>,
+    /// The size of the start region in meters.
+    /// Usually will be 236 but with a varregion this can be a multiple of 256
+    pub region_size_x: Option<i64>,
+    /// Undocumented
     pub region_size_y: Option<i64>,
-    pub circuit_code: u32, // Circuit code to use for all UDP connections
-    pub session_id: Option<Uuid>,  //UUID of this session
-    pub secure_session_id: Option<Uuid>, //the secure UUID of this session
-    pub inventory_root: Option<Vec<InventoryRootValues>>, // the ID of the user's root folder
-    pub inventory_skeleton: Option<Vec<InventorySkeletonValues>>, // details about the child folders of the root folder.
-    pub inventory_lib_root: Option<Vec<InventoryRootValues>>, // the ID of the library root folder
-    pub inventory_skeleton_lib: Option<Vec<InventorySkeletonValues>>, //details about the child folders of the library root folder
-    pub inventory_lib_owner: Option<Vec<AgentID>>, // the ID of the user that owns the library
-    pub map_server_url: Option<String>,            //URL from which to request map tiles
-    pub buddy_list: Option<Vec<BuddyListValues>>, // the user's friend list. Contains an entry for each friend
-    pub gestures: Option<Vec<GesturesValues>>,    // the gestures the user currently has active.
-    pub initial_outfit: Option<Vec<InitialOutfit>>, // use unknown, probably obsolete
-    pub global_textures: Option<Vec<GlobalTextures>>, // use unknown, probably obsolete
-    pub login: Option<bool>,                      // if logged in (should be true)
+    /// Circuit code to use for all UDP connections
+    pub circuit_code: u32,
+    /// UUID of this session
+    pub session_id: Option<Uuid>,
+    /// The secure UUID of this session
+    pub secure_session_id: Option<Uuid>,
+    /// The ID of the user's root folder
+    pub inventory_root: Option<Vec<InventoryRootValues>>,
+    /// Details about the child folders of the root folder
+    pub inventory_skeleton: Option<Vec<InventorySkeletonValues>>,
+    /// The ID of the library root folder
+    pub inventory_lib_root: Option<Vec<InventoryRootValues>>,
+    /// Details about the child folders of the library root folder
+    pub inventory_skeleton_lib: Option<Vec<InventorySkeletonValues>>,
+    /// The ID of the user that owns the library
+    pub inventory_lib_owner: Option<Vec<AgentID>>,
+    /// URL from which to request map tiles
+    pub map_server_url: Option<String>,
+    /// The user's friend list. Contains an entry for each friend
+    pub buddy_list: Option<Vec<BuddyListValues>>,
+    /// The gestures the user currently has active
+    pub gestures: Option<Vec<GesturesValues>>,
+    /// Use unknown, probably obsolete
+    pub initial_outfit: Option<Vec<InitialOutfit>>,
+    /// Use unknown, probably obsolete
+    pub global_textures: Option<Vec<GlobalTextures>>,
+    /// If logged in (should be true)
+    pub login: Option<bool>,
+    /// Undocumented
     pub login_flags: Option<Vec<LoginFlags>>,
+    /// Undocumented
     pub message: Option<String>,
+    /// Undocumented
     pub ui_config: Option<Vec<UiConfig>>,
-    pub event_categories: Option<String>, // unknown
+    /// Undocumented
+    pub event_categories: Option<String>,
+    /// Undocumented
     pub classified_categories: Option<Vec<ClassifiedCategoriesValues>>,
-    pub real_id: Option<String>,               //TODO: NOT DOCUMENTED!!
-    pub search: Option<String>,                //TODO: NOT DOCUMENTED!!
-    pub destination_guide_url: Option<String>, //TODO: NOT DOCUMENTED!!
-    pub event_notifications: Option<String>,   //TODO: NOT DOCUMENTED!!
-    pub max_agent_groups: Option<i64>,         //TODO: NOT DOCUMENTED!!
-    pub seconds_since_epoch: Option<i64>,      //TODO: NOT DOCUMENTED!!
+    /// Undocumented
+    pub real_id: Option<String>,
+    /// Undocumented
+    pub search: Option<String>,
+    /// Undocumented
+    pub destination_guide_url: Option<String>,
+    /// Undocumented
+    pub event_notifications: Option<String>,
+    /// Undocumented
+    pub max_agent_groups: Option<i64>,
+    /// Undocumented
+    pub seconds_since_epoch: Option<i64>,
 }
 impl fmt::Display for LoginResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -85,9 +134,9 @@ impl fmt::Display for LoginResponse {
         if let Some(seed_capability) = &self.seed_capability {
             output.push_str(&format!("seed_capability: {}\n", seed_capability));
         }
-            output.push_str(&format!("first_name: {}\n", self.first_name));
-            output.push_str(&format!("last_name: {}\n", self.last_name));
-       
+        output.push_str(&format!("first_name: {}\n", self.first_name));
+        output.push_str(&format!("last_name: {}\n", self.last_name));
+
         if let Some(agent_id) = &self.agent_id {
             output.push_str(&format!("agent_id: {}\n", agent_id));
         }
@@ -115,7 +164,7 @@ impl fmt::Display for LoginResponse {
         if let Some(region_size_y) = &self.region_size_y {
             output.push_str(&format!("region_size_y: {}\n", region_size_y));
         }
-            output.push_str(&format!("circuit_code: {}\n", self.circuit_code));
+        output.push_str(&format!("circuit_code: {}\n", self.circuit_code));
 
         if let Some(session_id) = &self.session_id {
             output.push_str(&format!("session_id: {}\n", session_id));
@@ -204,10 +253,12 @@ impl fmt::Display for LoginResponse {
 #[macro_export]
 macro_rules! nonoptional_u32_val {
     ($val:expr) => {
-
         match $val.as_i64() {
             Some(s) => Ok(s.try_into().unwrap()),
-            None => Err(ConversionError(concat!("Missing or invalid u32 for field: ", stringify!($val)))),
+            None => Err(ConversionError(concat!(
+                "Missing or invalid u32 for field: ",
+                stringify!($val)
+            ))),
         }
     };
 }
@@ -216,7 +267,10 @@ macro_rules! nonoptional_str_val {
     ($val:expr) => {
         match $val.as_str() {
             Some(s) => Ok(s.to_string()),
-            None => Err(ConversionError(concat!("Missing or invalid string for field: ", stringify!($val)))),
+            None => Err(ConversionError(concat!(
+                "Missing or invalid string for field: ",
+                stringify!($val)
+            ))),
         }
     };
 }
@@ -304,12 +358,16 @@ pub struct UiConfig {
 
 #[derive(Clone, Debug)]
 pub struct LoginFlags {
-    pub stipend_since_login: String, // stipend money recieved since last login
-    pub ever_logged_in: bool,        // if the account has ever logged in
-    pub seconds_since_epoch: Option<i64>, // server time in unix seconds since epoch
-    // TODO: no longer sent by osgrid server
-    pub daylight_savings: bool, // whether daylight savings is in effect for grid time
-    pub gendered: bool,         // mysterious!
+    /// Stipend money received since last login
+    pub stipend_since_login: String,
+    /// If the account has ever logged in
+    pub ever_logged_in: bool,
+    /// Server time in Unix seconds since epoch
+    pub seconds_since_epoch: Option<i64>,
+    /// TODO: No longer sent by OSGrid server
+    pub daylight_savings: bool,
+    /// Mysterious!
+    pub gendered: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -327,30 +385,39 @@ pub struct InitialOutfit {
 
 #[derive(Clone, Debug)]
 pub struct GesturesValues {
-    pub item_id: String,  // the item ID of the gesture in the user's inventory
-    pub asset_id: String, // the asset ID of the gesture
+    /// the item ID of the gesture in the user's inventory
+    pub item_id: String,
+    /// the asset ID of the gesture
+    pub asset_id: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct BuddyListValues {
-    pub buddy_id: String,                  //the UUID of the friend
-    pub buddy_rights_given: FriendsRights, // the rights given to this user.
+    /// the UUID of the friend
+    pub buddy_id: String,
+    /// the rights given to this user
+    pub buddy_rights_given: FriendsRights,
     pub buddy_rights_has: FriendsRights,
 }
 
 #[derive(Clone, Debug)]
 pub struct FriendsRights {
-    pub can_see_online: bool, // true if friend can see if you are online
-    pub can_see_on_map: bool, // true if friend can see where you are on the map
+    /// true if friends can see if you are online
+    pub can_see_online: bool,
+    /// true if friends can see where you are on the mpap
+    pub can_see_on_map: bool,
     pub can_modify_objects: bool,
 }
 
 /// details about the child folders of the root folder
 #[derive(Clone, Debug)]
 pub struct InventorySkeletonValues {
-    pub folder_id: String, // the ID of the folder
-    pub parent_id: String, // the ID of the containing folder
-    pub name: String,      // the name of the folder
+    /// The ID of the folder
+    pub folder_id: String,
+    /// The ID of the containing folder
+    pub parent_id: String,
+    /// The name of the folder
+    pub name: String,
     pub type_default: InventoryType,
     pub version: i32,
 }
@@ -399,6 +466,9 @@ pub struct HomeValues {
     pub look_at: (String, String, String),
 }
 
+// TODO: all of these parse functions should be Into functions.
+
+/// converts xmlrpc to agent_access enums
 fn parse_agent_access(agent_access: Option<&xmlrpc::Value>) -> Option<AgentAccess> {
     agent_access.map(|x| match x.clone().as_str().unwrap() {
         "M" => AgentAccess::Mature,
@@ -409,6 +479,7 @@ fn parse_agent_access(agent_access: Option<&xmlrpc::Value>) -> Option<AgentAcces
     })
 }
 
+// converts xmlrpc to inventory type enum
 fn parse_inventory_type(inventory_type: &xmlrpc::Value) -> InventoryType {
     match inventory_type.clone().as_i32().unwrap() {
         -1 => InventoryType::Unknown,
@@ -431,6 +502,7 @@ fn parse_inventory_type(inventory_type: &xmlrpc::Value) -> InventoryType {
     }
 }
 
+/// converts xmlrpc to string_3tuples
 fn string_3tuple(values: xmlrpc::Value) -> Option<(String, String, String)> {
     values.as_array().map(|x| {
         (
@@ -441,6 +513,7 @@ fn string_3tuple(values: xmlrpc::Value) -> Option<(String, String, String)> {
     })
 }
 
+/// converts friendRights int values to a FriendsRights struct
 fn generate_friends_rights(rights: i32) -> FriendsRights {
     match rights {
         1 => FriendsRights {
@@ -466,6 +539,7 @@ fn generate_friends_rights(rights: i32) -> FriendsRights {
     }
 }
 
+/// converts xlmrpc to a buddy list
 fn parse_buddy_list(values: Option<&xmlrpc::Value>) -> Option<Vec<BuddyListValues>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -484,6 +558,7 @@ fn parse_buddy_list(values: Option<&xmlrpc::Value>) -> Option<Vec<BuddyListValue
     Some(value_vec)
 }
 
+/// converts xmlrpc to an inventory_skeelton object
 fn parse_inventory_skeleton(
     values: Option<&xmlrpc::Value>,
 ) -> Option<Vec<InventorySkeletonValues>> {
@@ -506,6 +581,7 @@ fn parse_inventory_skeleton(
     Some(value_vec)
 }
 
+/// converts xmlrpc to an inventory_root obect
 fn parse_inventory_root(values: Option<&xmlrpc::Value>) -> Option<Vec<InventoryRootValues>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -520,6 +596,7 @@ fn parse_inventory_root(values: Option<&xmlrpc::Value>) -> Option<Vec<InventoryR
     Some(value_vec)
 }
 
+/// converts xmlrpc to an inventory_lib_owner object
 fn parse_inventory_lib_owner(values: Option<&xmlrpc::Value>) -> Option<Vec<AgentID>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -534,6 +611,7 @@ fn parse_inventory_lib_owner(values: Option<&xmlrpc::Value>) -> Option<Vec<Agent
     Some(value_vec)
 }
 
+/// converts xmlrpc to a gesturesvalues object
 fn parse_gestures(values: Option<&xmlrpc::Value>) -> Option<Vec<GesturesValues>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -548,7 +626,7 @@ fn parse_gestures(values: Option<&xmlrpc::Value>) -> Option<Vec<GesturesValues>>
     }
     Some(value_vec)
 }
-
+/// converts an xmlrpc to a classified catoegories values object  
 fn parse_classified_categories(
     values: Option<&xmlrpc::Value>,
 ) -> Option<Vec<ClassifiedCategoriesValues>> {
@@ -566,6 +644,7 @@ fn parse_classified_categories(
     Some(value_vec)
 }
 
+/// converts xmlrpc to an IntiialOutfit object
 fn parse_initial_outfit(values: Option<&xmlrpc::Value>) -> Option<Vec<InitialOutfit>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -581,6 +660,7 @@ fn parse_initial_outfit(values: Option<&xmlrpc::Value>) -> Option<Vec<InitialOut
     Some(value_vec)
 }
 
+/// converts xmlrpc to a GlobalTextures object  
 fn parse_global_textures(values: Option<&xmlrpc::Value>) -> Option<Vec<GlobalTextures>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -597,6 +677,7 @@ fn parse_global_textures(values: Option<&xmlrpc::Value>) -> Option<Vec<GlobalTex
     Some(value_vec)
 }
 
+/// converts xmlrpc to LoginFlags
 fn parse_login_flags(values: Option<&xmlrpc::Value>) -> Option<Vec<LoginFlags>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -627,6 +708,7 @@ fn parse_login_flags(values: Option<&xmlrpc::Value>) -> Option<Vec<LoginFlags>> 
     Some(value_vec)
 }
 
+/// converts xlmrpc to UiConfig
 fn parse_ui_config(values: Option<&xmlrpc::Value>) -> Option<Vec<UiConfig>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -645,10 +727,10 @@ fn parse_ui_config(values: Option<&xmlrpc::Value>) -> Option<Vec<UiConfig>> {
     Some(value_vec)
 }
 
+/// converts xmlrpc to a HomeValues object
 // this is literally the worst thing I've ever been forced to do
 // why this is the singular field that is passed as a string is beyond me
 // this is so cursed and I hate it
-//
 impl From<xmlrpc::Value> for HomeValues {
     fn from(val: xmlrpc::Value) -> Self {
         let mut home_values_object = HomeValues {
@@ -660,11 +742,21 @@ impl From<xmlrpc::Value> for HomeValues {
         // Convert xmlrpc::Value to string
         let valuestring = match val.as_str() {
             Some(s) => s.to_string(),
-            None => return HomeValues {
-                region_handle: ("Error".to_string(), "Invalid value".to_string()),
-                look_at: ("Error".to_string(), "Invalid value".to_string(), "Invalid value".to_string()),
-                position: ("Error".to_string(), "Invalid value".to_string(), "Invalid value".to_string()),
-            },
+            None => {
+                return HomeValues {
+                    region_handle: ("Error".to_string(), "Invalid value".to_string()),
+                    look_at: (
+                        "Error".to_string(),
+                        "Invalid value".to_string(),
+                        "Invalid value".to_string(),
+                    ),
+                    position: (
+                        "Error".to_string(),
+                        "Invalid value".to_string(),
+                        "Invalid value".to_string(),
+                    ),
+                }
+            }
         };
 
         // Split the string by "],"
@@ -684,10 +776,14 @@ impl From<xmlrpc::Value> for HomeValues {
             match label.as_str() {
                 "region_handle" => {
                     if values.len() == 2 {
-                        home_values_object.region_handle = (values[0].to_string(), values[1].to_string());
+                        home_values_object.region_handle =
+                            (values[0].to_string(), values[1].to_string());
                     } else {
                         return HomeValues {
-                            region_handle: ("Error".to_string(), "Invalid number of values".to_string()),
+                            region_handle: (
+                                "Error".to_string(),
+                                "Invalid number of values".to_string(),
+                            ),
                             look_at: home_values_object.look_at,
                             position: home_values_object.position,
                         };
@@ -703,7 +799,11 @@ impl From<xmlrpc::Value> for HomeValues {
                     } else {
                         return HomeValues {
                             region_handle: home_values_object.region_handle,
-                            look_at: ("Error".to_string(), "Invalid number of values".to_string(), "Invalid value".to_string()),
+                            look_at: (
+                                "Error".to_string(),
+                                "Invalid number of values".to_string(),
+                                "Invalid value".to_string(),
+                            ),
                             position: home_values_object.position,
                         };
                     }
@@ -719,7 +819,11 @@ impl From<xmlrpc::Value> for HomeValues {
                         return HomeValues {
                             region_handle: home_values_object.region_handle,
                             look_at: home_values_object.look_at,
-                            position: ("Error".to_string(), "Invalid number of values".to_string(), "Invalid value".to_string()),
+                            position: (
+                                "Error".to_string(),
+                                "Invalid number of values".to_string(),
+                                "Invalid value".to_string(),
+                            ),
                         };
                     }
                 }
@@ -731,21 +835,10 @@ impl From<xmlrpc::Value> for HomeValues {
     }
 }
 
-
-#[derive(Debug)]
-struct ConversionError(&'static str);
-
-impl fmt::Display for ConversionError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl Error for ConversionError {}
-
+/// converts from xlmrpc to a LoginResponse
 impl TryFrom<xmlrpc::Value> for LoginResponse {
     type Error = Box<dyn Error>;
-    fn try_from(val: xmlrpc::Value) ->  Result<Self, Self::Error>  {
+    fn try_from(val: xmlrpc::Value) -> Result<Self, Self::Error> {
         Ok(LoginResponse {
             home: Some(val["home"].clone().into()),
             look_at: string_3tuple(val["look_at"].clone()),
@@ -788,12 +881,11 @@ impl TryFrom<xmlrpc::Value> for LoginResponse {
 }
 impl TryFrom<xmlrpc::Value> for LoginFailure {
     type Error = Box<dyn Error>;
-    fn try_from(val: xmlrpc::Value) ->  Result<Self, Self::Error>  {
+    fn try_from(val: xmlrpc::Value) -> Result<Self, Self::Error> {
         Ok(LoginFailure {
             login: str_val!(val["login"]).ok_or(ConversionError("Missing login"))?,
             message: str_val!(val["message"]).ok_or(ConversionError("Missing message"))?,
-            reason: str_val!(val["reason"]).ok_or(ConversionError("Missing reason"))?
-        }
-        )
+            reason: str_val!(val["reason"]).ok_or(ConversionError("Missing reason"))?,
+        })
     }
 }

--- a/crates/login/src/models/simulator_login_protocol.rs
+++ b/crates/login/src/models/simulator_login_protocol.rs
@@ -4,39 +4,60 @@
 ///
 #[derive(Clone, Default)]
 pub struct SimulatorLoginProtocol {
-    pub first: String,  // First name of the user
-    pub last: String,   // Last name of the user
-    pub passwd: String, // MD5 hash of the user's password with the string "$1$" prepended
-    pub start: String,  // The region in which the user should start upon login. This can be one of
-    // "home" - start in the user's home location
-    // "last" - start in the location where the user last logged out
-    // a specific location - in the format
-    // uri:<region-name>&<x-coord>&<y-coord>&<z-coord>
-    // for example, the string "uri:test&128&128&0" says the user
-    // should log in to the center of the region named test, and
-    // the avatar should be placed on the ground if the
-    // z-coordinate is below the terrain.
-    pub channel: String,  // Name of the viewer/client connecting
-    pub version: String,  // Version of the viewer/client connecting
-    pub platform: String, // Platform the viewer/client is connecting from. Can be one of
-    // lin - linux
-    // mac - mac
-    // win - windows
-    pub platform_string: String, // The operating system description and version (e.g. "Linux 5.8", "Fedora 32")
-    pub platform_version: String, // Operating system version
-    pub mac: String,             // The MAC address of the network card used by the client/viewer
-    pub id0: String, // A hardware hash based on the serial number of the user's first hard drive
-    // used to uniquely identify computers and track users
-    pub agree_to_tos: bool, // Has user agreed to the terms of service. Boolean true/false
-    pub read_critical: bool, // Has user read terms of service or other docs. Boolean true/false
-    pub viewer_digest: Option<String>, // MD5 hash of the viewer executable
-    pub address_size: i32,  // TODO: figure out what this means
-    pub extended_errors: bool, // TODO: figure out what this means
-    pub last_exec_event: Option<i32>, // TODO: figure out what this means
-    pub last_exec_duration: i32, // TODO: figure out what this means
-    pub skipoptional: Option<bool>, // TODO: figure out what this means :/
-    pub host_id: String,    // TODO: undocumented also
-    pub mfa_hash: String,   // TODO: Undocumented
+    /// First name of the user
+    pub first: String,
+    /// Last name of the user
+    pub last: String,
+    /// MD5 hash of the user's password with the string "$1$" prepended
+    pub passwd: String,
+    /// The region in which the user should start upon login. This can be one of
+    /// "home" - start in the user's home location
+    /// "last" - start in the location where the user last logged out
+    /// a specific location - in the format
+    /// uri:<region-name>&<x-coord>&<y-coord>&<z-coord>
+    /// for example, the string "uri:test&128&128&0" says the user
+    /// should log in to the center of the region named test, and
+    /// the avatar should be placed on the ground if the
+    /// z-coordinate is below the terrain.
+    pub start: String,
+    /// Name of the viewer/client connecting
+    pub channel: String,
+    /// Version of the viewer/client connecting
+    pub version: String,
+    /// Platform the viewer/client is connecting from. Can be one of
+    /// lin - linux
+    /// mac - mac
+    /// win - windows
+    pub platform: String,
+    /// The operating system description and version (e.g. "Linux 5.8", "Fedora 32")
+    pub platform_string: String,
+    /// Operating system version
+    pub platform_version: String,
+    /// The MAC address of the network card used by the client/viewer
+    pub mac: String,
+    /// A hardware hash based on the serial number of the user's first hard drive
+    /// Used to uniquely identify computers and track users
+    pub id0: String,
+    /// Has user agreed to the terms of service. Boolean true/false
+    pub agree_to_tos: bool,
+    /// Has user read terms of service or other docs. Boolean true/false
+    pub read_critical: bool,
+    /// MD5 hash of the viewer executable
+    pub viewer_digest: Option<String>,
+    /// TODO: Figure out what this means
+    pub address_size: i32,
+    /// TODO: Figure out what this means
+    pub extended_errors: bool,
+    /// TODO: Figure out what this means
+    pub last_exec_event: Option<i32>,
+    /// TODO: Figure out what this means
+    pub last_exec_duration: i32,
+    /// TODO: Figure out what this means :/
+    pub skipoptional: Option<bool>,
+    /// TODO: Undocumented also
+    pub host_id: String,
+    /// TODO: Undocumented
+    pub mfa_hash: String,
     pub token: String,
     pub options: SimulatorLoginOptions,
 }
@@ -50,28 +71,42 @@ pub struct SimulatorLoginOptions {
     pub adult_compliant: Option<bool>,
     pub advanced_mode: Option<bool>,
     pub avatar_picker_url: Option<bool>,
-    pub buddy_list: Option<bool>, // buddy-list in xml
+    /// Buddy-list in XML
+    pub buddy_list: Option<bool>,
     pub classified_categories: Option<bool>,
     pub currency: Option<bool>,
     pub destination_guide_url: Option<bool>,
     pub display_names: Option<bool>,
     pub event_categories: Option<bool>,
     pub gestures: Option<bool>,
-    pub global_textures: Option<bool>,     // global-textures in xml
-    pub inventory_root: Option<bool>,      // inventory-root in xml
-    pub inventory_skeleton: Option<bool>,  // inventory-skeleton in xml
-    pub inventory_lib_root: Option<bool>,  // inventory-lib-root in xml
-    pub inventory_lib_owner: Option<bool>, // inventory-lib-owner in xml
-    pub inventory_skel_lib: Option<bool>,  // inventory-skel-lib in xml
-    pub login_flags: Option<bool>,         // login-flags in xml
-    pub max_agent_groups: Option<bool>,    // max-agent-groups in xml
+    /// Global-textures in XML
+    pub global_textures: Option<bool>,
+    /// Inventory-root in XML
+    pub inventory_root: Option<bool>,
+    /// Inventory-skeleton in XML
+    pub inventory_skeleton: Option<bool>,
+    /// Inventory-lib-root in XML
+    pub inventory_lib_root: Option<bool>,
+    /// Inventory-lib-owner in XML
+    pub inventory_lib_owner: Option<bool>,
+    /// Inventory-skel-lib in XML
+    pub inventory_skel_lib: Option<bool>,
+    /// Login-flags in XML
+    pub login_flags: Option<bool>,
+    /// Max-agent-groups in XML
+    pub max_agent_groups: Option<bool>,
     pub max_groups: Option<bool>,
-    pub map_server_url: Option<bool>, // map-server-url in xml
-    pub newuser_config: Option<bool>, // newuser-config in xml
+    /// Map-server-url in XML
+    pub map_server_url: Option<bool>,
+    /// Newuser-config in XML
+    pub newuser_config: Option<bool>,
     pub search: Option<bool>,
-    pub tutorial_setting: Option<bool>, // tutorial-setting in xml
-    pub ui_config: Option<bool>,        // ui-config in xml
-    pub voice_config: Option<bool>,     // voice-config in xml
+    /// Tutorial-setting in XML
+    pub tutorial_setting: Option<bool>,
+    /// UI-config in XML
+    pub ui_config: Option<bool>,
+    /// Voice-config in XML
+    pub voice_config: Option<bool>,
 }
 
 ///Creates value type from a SimulatorLoginOption struct
@@ -243,6 +278,7 @@ impl From<SimulatorLoginOptions> for xmlrpc::Value {
     }
 }
 
+/// converts an xmlrpc boolean to a real int
 fn bool_to_int(value: bool) -> xmlrpc::Value {
     if value {
         xmlrpc::Value::Int(1)
@@ -310,13 +346,28 @@ impl From<SimulatorLoginProtocol> for xmlrpc::Value {
     }
 }
 
-// this struct contains the information for a login using only the user-supplied information
+/// this struct contains the information for a login using only the user-supplied information
 pub struct Login {
+    /// Name of the viewer/client connecting
     pub channel: String,
+    /// first name of the user
     pub first: String,
+    /// last name of the user 
     pub last: String,
+    /// MD5 hash of the user's password with the string "$1$" prepended
     pub passwd: String,
+    /// The region in which the user should start upon login. This can be one of
+    /// "home" - start in the user's home location
+    /// "last" - start in the location where the user last logged out
+    /// a specific location - in the format
+    /// uri:<region-name>&<x-coord>&<y-coord>&<z-coord>
+    /// for example, the string "uri:test&128&128&0" says the user
+    /// should log in to the center of the region named test, and
+    /// the avatar should be placed on the ground if the
+    /// z-coordinate is below the terrain.
     pub start: String,
+    /// Has user agreed to the terms of service. Boolean true/false
     pub agree_to_tos: bool,
+    /// Has user read other important doc. Boolean true/false
     pub read_critical: bool,
 }

--- a/crates/login/tests/login.rs
+++ b/crates/login/tests/login.rs
@@ -148,20 +148,19 @@ async fn test_against_local() {
         });
 
         tokio::task::spawn_blocking(|| {
-
             let login_response = login(
                 EXAMPLE_LOGIN.clone(),
                 build_test_url("http://127.0.0.1", 9000),
             );
-        match login_response {
-            Ok(LoginResult::Success(response)) => {
-                assert!(response.first_name == "default".to_string());
-                assert!(response.last_name == "user".to_string());
-            },
-            Ok(LoginResult::Failure(failure)) => {
-                println!("Login failed: {}", failure.message);
-            },
-            Err(e) => panic!("Login failed: {:?}", e),
+            match login_response {
+                Ok(LoginResult::Success(response)) => {
+                    assert!(response.first_name == *"default");
+                    assert!(response.last_name == *"user");
+                }
+                Ok(LoginResult::Failure(failure)) => {
+                    println!("Login failed: {}", failure.message);
+                }
+                Err(e) => panic!("Login failed: {:?}", e),
             }
         });
         sleep(Duration::from_secs(5)).await;
@@ -208,16 +207,15 @@ async fn test_build_login() {
         tokio::task::spawn_blocking(|| {
             let login_response = login(login_data, build_test_url("http://127.0.0.1", 9000));
             match login_response {
-            Ok(LoginResult::Success(response)) => {
-                assert!(response.first_name == "default".to_string());
-                assert!(response.last_name == "user".to_string());
-            },
-            Ok(LoginResult::Failure(failure)) => {
-                info!("Login failed with: {}",  failure.message);
-            },
-            Err(e) => panic!("Login failed: {:?}", e),
+                Ok(LoginResult::Success(response)) => {
+                    assert!(response.first_name == *"default");
+                    assert!(response.last_name == *"user");
+                }
+                Ok(LoginResult::Failure(failure)) => {
+                    info!("Login failed with: {}", failure.message);
+                }
+                Err(e) => panic!("Login failed: {:?}", e),
             }
-
         });
 
         sleep(Duration::from_secs(5)).await;
@@ -350,7 +348,6 @@ fn test_xml_generation() {
     let req = xmlrpc::Request::new("login_to_simulator").arg(EXAMPLE_LOGIN.clone());
     debug_request_xml(req)
 }
-
 
 /// helper function for building URL. May be unnescecary
 fn build_test_url(url: &str, port: u16) -> String {


### PR DESCRIPTION
changes the login so that instead of returning xmlrpc, it returns a LoginResult, which can be a LoginResponse, or a LoginError. This makes handling errors easier, and allows other components to use the LoginResponse struct instead of having to parse the xml themselves. 