### PR TITLE
Adds packet queue

### DIFF
--- a/crates/login/tests/login.rs
+++ b/crates/login/tests/login.rs
@@ -24,7 +24,6 @@ fn init_logger() {
         .try_init();
 }
 
-
 lazy_static! {
     static ref EXAMPLE_LOGIN: SimulatorLoginProtocol = SimulatorLoginProtocol {
         address_size: 64,
@@ -250,7 +249,6 @@ async fn setup_server(
     sim_server
 }
 
-
 #[test]
 fn test_xml_generation() {
     let req = xmlrpc::Request::new("login_to_simulator").arg(EXAMPLE_LOGIN.clone());
@@ -275,4 +273,3 @@ fn debug_request_xml(xml: xmlrpc::Request) {
         Err(e) => println!("failed to debug request xml {}", e),
     };
 }
-

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -10,6 +10,8 @@ byte = "0.2.6"
 bitflags = "1.3.2"
 metaverse_utils = { path = "../utils" }
 actix = "0.13.5"
+tokio = { version = "1.14.0", features = ["full"] }
+futures = "0.3"
 [dependencies.uuid]
 version = "1.10.0"
 features = [

--- a/crates/messages/src/models/circuit_code.rs
+++ b/crates/messages/src/models/circuit_code.rs
@@ -3,6 +3,8 @@ use crate::models::packet::{Packet, PacketData};
 use std::io;
 use uuid::Uuid;
 
+use super::packet::MessageType;
+
 impl Packet {
     pub fn new_circuit_code(circuit_code_block: CircuitCodeData) -> Self {
         Packet {
@@ -41,12 +43,22 @@ impl PacketData for CircuitCodeData {
             id,
         })
     }
-
     fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(36);
         bytes.extend_from_slice(&self.code.to_le_bytes());
         bytes.extend(self.session_id.as_bytes());
         bytes.extend(self.id.as_bytes());
         bytes
+    }
+    fn on_receive(
+        &self,
+        _: std::sync::Arc<
+            tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>,
+        >,
+    ) {
+        // this will never be received, only sent
+    }
+    fn message_type(&self) -> MessageType {
+        MessageType::Outgoing
     }
 }

--- a/crates/messages/src/models/coarse_location_update.rs
+++ b/crates/messages/src/models/coarse_location_update.rs
@@ -1,6 +1,9 @@
-use super::packet::PacketData;
+use super::packet::{MessageType, PacketData};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Cursor, Write};
+
+/// ID: 6
+/// Frequency: Medium
 
 #[derive(Debug)]
 pub struct MinimapEntities {
@@ -73,5 +76,16 @@ impl PacketData for CoarseLocationUpdate {
 
         bytes
     }
+    fn on_receive(
+        &self,
+        _: std::sync::Arc<
+            tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>,
+        >,
+    ) {
+        // add to a queue
+        // implement later
+    }
+    fn message_type(&self) -> MessageType {
+        MessageType::Event
+    }
 }
-

--- a/crates/messages/src/models/disable_simulator.rs
+++ b/crates/messages/src/models/disable_simulator.rs
@@ -1,5 +1,8 @@
-use super::packet::PacketData;
+use super::packet::{MessageType, PacketData};
 use std::io;
+
+// ID: 152
+// Frequency: Low
 
 #[derive(Debug)]
 pub struct DisableSimulator {}
@@ -10,5 +13,16 @@ impl PacketData for DisableSimulator {
     }
     fn to_bytes(&self) -> Vec<u8> {
         vec![]
+    }
+    fn on_receive(
+        &self,
+        _: std::sync::Arc<
+            tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>,
+        >,
+    ) {
+        // implement later
+    }
+    fn message_type(&self) -> MessageType {
+        MessageType::Event
     }
 }

--- a/crates/messages/src/models/header.rs
+++ b/crates/messages/src/models/header.rs
@@ -1,5 +1,5 @@
-use std::io;
 use core::fmt;
+use std::io;
 
 // TODO: change the flags to bitflags
 pub const MSG_RELIABLE: u8 = 0x01;
@@ -139,12 +139,12 @@ pub enum PacketFrequency {
     Medium,
     Low,
 }
-impl fmt::Display for PacketFrequency{
+impl fmt::Display for PacketFrequency {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PacketFrequency::High => write!(f, "High"),
             PacketFrequency::Medium => write!(f, "Medium"),
-            PacketFrequency::Low => write!(f, "Low")
+            PacketFrequency::Low => write!(f, "Low"),
         }
     }
 }

--- a/crates/messages/src/models/packet_ack.rs
+++ b/crates/messages/src/models/packet_ack.rs
@@ -1,6 +1,9 @@
-use super::packet::PacketData;
+use super::packet::{MessageType, PacketData};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Cursor};
+
+// ID: 65531
+// Frequency: Low
 
 #[derive(Debug)]
 pub struct PacketAck {
@@ -32,5 +35,25 @@ impl PacketData for PacketAck {
         }
 
         bytes
+    }
+
+    fn on_receive(
+        &self,
+        ack_queue: std::sync::Arc<
+            tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>,
+        >,
+    ) {
+        let mut queue = futures::executor::block_on(ack_queue.lock());
+        for id in &self.packet_ids {
+            if let Some(sender) = queue.remove(&id) {
+                let _ = sender.send(());
+            } else {
+                println!("No pending ack found for request ID: {}", id);
+            }
+        }
+    }
+
+    fn message_type(&self) -> MessageType {
+        MessageType::Acknowledgment
     }
 }

--- a/crates/messages/src/models/packet_types.rs
+++ b/crates/messages/src/models/packet_types.rs
@@ -16,8 +16,14 @@ pub enum PacketType {
 
 impl PacketType {
     pub fn from_id(id: u16, frequency: PacketFrequency, bytes: &[u8]) -> io::Result<Self> {
-        // the packets are organized by frquency. 
-        // I really don't like it, but there's nothing I can do about it 
+        // the packets are organized by frquency.
+        // I really don't like it, but there's nothing I can do about it
+        // I will eventually organize these by type
+        // Acknowledgements,
+        // Requests,
+        // Commands,
+        // Errors,
+        // Data.
         match frequency {
             PacketFrequency::High => match id {
                 id => Err(io::Error::new(

--- a/crates/messages/tests/acks.rs
+++ b/crates/messages/tests/acks.rs
@@ -1,8 +1,5 @@
 use hex::FromHex;
-use metaverse_messages::models::{
-    header::Header,
-    packet_types::PacketType,
-};
+use metaverse_messages::models::{header::Header, packet::Packet, packet_types::PacketType};
 
 #[test]
 fn test_acks_parse() {
@@ -10,24 +7,10 @@ fn test_acks_parse() {
         Ok(bytes) => bytes,
         Err(_) => panic!("failed"),
     };
-    println!("packet bytes are: {:?}", test_packet);
-    let test_header = Header::try_from_bytes(&test_packet).unwrap();
-    println!("header is {:?}", test_header);
-    if test_header.size.unwrap_or(0) < test_packet.len() {
-        let slice = &test_packet[test_header.size.unwrap()..];
-        println!("data is {:?}", slice);
-    } else {
-        println!("Index out of bounds for slicing");
+    match Packet::from_bytes(&test_packet) {
+        Ok(packet) => println!("Packet created successfully: {:?}", packet),
+        Err(e) => eprintln!("Error creating packet: {}", e),
     }
-    let body_bytes = &test_packet[test_header.size.unwrap_or(0)..];
-    let body = match PacketType::from_id(test_header.id, test_header.frequency, body_bytes) {
-        Ok(body) => body,
-        Err(e) => {
-            println!("Error parsing packet body: {:?}", e);
-            return;
-        }
-    };
-    println!("Body Received: {:?}", body);
 }
 
 #[test]
@@ -36,22 +19,8 @@ fn test_acks_firestorm_parse() {
         Ok(bytes) => bytes,
         Err(_) => panic!("failed"),
     };
-    println!("packet bytes are: {:?}", test_packet);
-    let test_header = Header::try_from_bytes(&test_packet).unwrap();
-    println!("header is {:?}", test_header);
-    if test_header.size.unwrap_or(0) < test_packet.len() {
-        let slice = &test_packet[test_header.size.unwrap()..];
-        println!("data is {:?}", slice);
-    } else {
-        println!("Index out of bounds for slicing");
+    match Packet::from_bytes(&test_packet) {
+        Ok(packet) => println!("Packet created successfully: {:?}", packet),
+        Err(e) => eprintln!("Error creating packet: {}", e),
     }
-    let body_bytes = &test_packet[test_header.size.unwrap_or(0)..];
-    let body = match PacketType::from_id(test_header.id, test_header.frequency, body_bytes) {
-        Ok(body) => body,
-        Err(e) => {
-            println!("Error parsing packet body: {:?}", e);
-            return;
-        }
-    };
-    println!("Body Received: {:?}", body);
 }

--- a/crates/messages/tests/circuit_code.rs
+++ b/crates/messages/tests/circuit_code.rs
@@ -1,5 +1,5 @@
 use hex::FromHex;
-use metaverse_messages::models::{header::Header, packet_types::PacketType};
+use metaverse_messages::models::packet::Packet;
 
 #[test]
 fn test_use_circuit_code_firestorm_parse() {
@@ -7,24 +7,10 @@ fn test_use_circuit_code_firestorm_parse() {
         Ok(bytes) => bytes,
         Err(_) => panic!("failed"),
     };
-    println!("packet bytes are: {:?}", test_packet);
-    let test_header = Header::try_from_bytes(&test_packet).unwrap();
-    println!("header is {:?}", test_header);
-    if test_header.size.unwrap_or(0) < test_packet.len() {
-        let slice = &test_packet[test_header.size.unwrap()..];
-        println!("data is {:?}", slice);
-    } else {
-        println!("Index out of bounds for slicing");
+    match Packet::from_bytes(&test_packet) {
+        Ok(packet) => println!("Packet created successfully: {:?}", packet),
+        Err(e) => eprintln!("Error creating packet: {}", e),
     }
-    let body_bytes = &test_packet[test_header.size.unwrap_or(0)..];
-    let body = match PacketType::from_id(test_header.id, test_header.frequency, body_bytes) {
-        Ok(body) => body,
-        Err(e) => {
-            println!("Error parsing packet body: {:?}", e);
-            return;
-        }
-    };
-    println!("Body Received: {:?}", body);
 }
 
 #[test]
@@ -33,22 +19,8 @@ fn test_acks_firestorm_parse() {
         Ok(bytes) => bytes,
         Err(_) => panic!("failed"),
     };
-    println!("packet bytes are: {:?}", test_packet);
-    let test_header = Header::try_from_bytes(&test_packet).unwrap();
-    println!("header is {:?}", test_header);
-    if test_header.size.unwrap_or(0) < test_packet.len() {
-        let slice = &test_packet[test_header.size.unwrap()..];
-        println!("data is {:?}", slice);
-    } else {
-        println!("Index out of bounds for slicing");
+    match Packet::from_bytes(&test_packet) {
+        Ok(packet) => println!("Packet created successfully: {:?}", packet),
+        Err(e) => eprintln!("Error creating packet: {}", e),
     }
-    let body_bytes = &test_packet[test_header.size.unwrap_or(0)..];
-    let body = match PacketType::from_id(test_header.id, test_header.frequency, body_bytes) {
-        Ok(body) => body,
-        Err(e) => {
-            println!("Error parsing packet body: {:?}", e);
-            return;
-        }
-    };
-    println!("Body Received: {:?}", body);
 }

--- a/crates/messages/tests/coarse_location_update.rs
+++ b/crates/messages/tests/coarse_location_update.rs
@@ -1,5 +1,5 @@
 use hex::FromHex;
-use metaverse_messages::models::{header::Header, packet_types::PacketType};
+use metaverse_messages::models::packet::Packet;
 
 #[test]
 fn test_coarse_location_update() {
@@ -7,24 +7,10 @@ fn test_coarse_location_update() {
         Ok(bytes) => bytes,
         Err(_) => panic!("failed"),
     };
-    println!("packet bytes are: {:?}", test_packet);
-    let test_header = Header::try_from_bytes(&test_packet).unwrap();
-    println!("header is {:?}", test_header);
-    if test_header.size.unwrap_or(0) < test_packet.len() {
-        let slice = &test_packet[test_header.size.unwrap()..];
-        println!("data is {:?}", slice);
-    } else {
-        println!("Index out of bounds for slicing");
+    match Packet::from_bytes(&test_packet) {
+        Ok(packet) => println!("Packet created successfully: {:?}", packet),
+        Err(e) => eprintln!("Error creating packet: {}", e),
     }
-    let body_bytes = &test_packet[test_header.size.unwrap_or(0)..];
-    let body = match PacketType::from_id(test_header.id, test_header.frequency, body_bytes) {
-        Ok(body) => body,
-        Err(e) => {
-            println!("Error parsing packet body: {:?}", e);
-            return;
-        }
-    };
-    println!("Body Received: {:?}", body);
 }
 
 #[test]
@@ -33,22 +19,8 @@ fn test_coarse_location_update_firestorm() {
         Ok(bytes) => bytes,
         Err(_) => panic!("failed"),
     };
-    println!("packet bytes are: {:?}", test_packet);
-    let test_header = Header::try_from_bytes(&test_packet).unwrap();
-    println!("header is {:?}", test_header);
-    if test_header.size.unwrap_or(0) < test_packet.len() {
-        let slice = &test_packet[test_header.size.unwrap()..];
-        println!("data is {:?}", slice);
-    } else {
-        println!("Index out of bounds for slicing");
+    match Packet::from_bytes(&test_packet) {
+        Ok(packet) => println!("Packet created successfully: {:?}", packet),
+        Err(e) => eprintln!("Error creating packet: {}", e),
     }
-    let body_bytes = &test_packet[test_header.size.unwrap_or(0)..];
-    let body = match PacketType::from_id(test_header.id, test_header.frequency, body_bytes) {
-        Ok(body) => body,
-        Err(e) => {
-            println!("Error parsing packet body: {:?}", e);
-            return;
-        }
-    };
-    println!("Body Received: {:?}", body);
 }

--- a/crates/messages/tests/disable_simulator.rs
+++ b/crates/messages/tests/disable_simulator.rs
@@ -1,5 +1,5 @@
 use hex::FromHex;
-use metaverse_messages::models::{header::Header, packet_types::PacketType};
+use metaverse_messages::models::packet::Packet;
 
 #[test]
 fn test_disable_simulator() {
@@ -7,22 +7,8 @@ fn test_disable_simulator() {
         Ok(bytes) => bytes,
         Err(_) => panic!("failed"),
     };
-    println!("packet bytes are: {:?}", test_packet);
-    let test_header = Header::try_from_bytes(&test_packet).unwrap();
-    println!("header is {:?}", test_header);
-    if test_header.size.unwrap_or(0) < test_packet.len() {
-        let slice = &test_packet[test_header.size.unwrap()..];
-        println!("data is {:?}", slice);
-    } else {
-        println!("Index out of bounds for slicing");
+    match Packet::from_bytes(&test_packet) {
+        Ok(packet) => println!("Packet created successfully: {:?}", packet),
+        Err(e) => eprintln!("Error creating packet: {}", e),
     }
-    let body_bytes = &test_packet[test_header.size.unwrap_or(0)..];
-    let body = match PacketType::from_id(test_header.id, test_header.frequency, body_bytes) {
-        Ok(body) => body,
-        Err(e) => {
-            println!("Error parsing packet body: {:?}", e);
-            return;
-        }
-    };
-    println!("Body Received: {:?}", body);
 }

--- a/crates/messages/tests/packet_debugger.rs
+++ b/crates/messages/tests/packet_debugger.rs
@@ -1,0 +1,42 @@
+// this is not a test file!
+// this is a command line utility for decoding UDP packets!
+
+use hex::FromHex;
+use std::io::{self, Write};
+
+use metaverse_messages::models::packet::Packet;
+
+#[test]
+fn test_packet_decoder() {
+    println!("Metaverse Packet Analyzer");
+    println!("get the packet body as a hex stream from wireshark");
+    println!("Type 'exit' to quit.");
+
+    loop {
+        let mut input = String::new();
+        print!("Enter packet data as hex stream: ");
+        io::stdout().flush().expect("Failed to flush stdout");
+
+        io::stdin()
+            .read_line(&mut input)
+            .expect("Failed to read line");
+
+        // Remove any trailing newline characters
+        let input = input.trim();
+
+        // Convert the input string to bytes
+        let bytes = match Vec::from_hex(input) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                eprintln!("could not decode hex");
+                continue;
+            }
+        };
+
+        // Create a Packet instance from the byte slice
+        match Packet::from_bytes(&bytes) {
+            Ok(packet) => println!("Packet created successfully: {:?}", packet),
+            Err(e) => eprintln!("Error creating packet: {}", e),
+        }
+    }
+}

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.9"
 log = "0.4"
 actix = "0.13.5"
 hex = "0.4"
+rand = "0.8"
 
 actix-rt = "2.7"
 [dependencies.uuid]

--- a/crates/session/src/models/mailbox.rs
+++ b/crates/session/src/models/mailbox.rs
@@ -1,18 +1,37 @@
 use actix::prelude::*;
 use log::{error, info};
-use metaverse_messages::models::packet::Packet;
+use metaverse_messages::models::packet::{MessageType, Packet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::net::UdpSocket;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 
 pub struct Mailbox {
     pub socket: Option<Arc<UdpSocket>>,
     pub url: String,
     pub server_socket: u16,
     pub client_socket: u16,
+
+    pub ack_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+    pub request_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+    pub event_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+    pub command_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+    pub error_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+    pub data_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
 }
 
 impl Mailbox {
-    async fn start_udp_read(sock: Arc<UdpSocket>) {
+    async fn start_udp_read(
+        ack_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+        command_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+        data_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+        event_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+        request_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+        error_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+        outgoing_queue: Arc<Mutex<HashMap<u32, oneshot::Sender<()>>>>,
+        sock: Arc<UdpSocket>,
+    ) {
         let mut buf = [0; 1024];
         loop {
             info!("udp read is running");
@@ -24,6 +43,29 @@ impl Mailbox {
                         Err(e) => {
                             error!("failed to parse packet: {:?}", e);
                             continue;
+                        }
+                    };
+                    match packet.body.message_type() {
+                        MessageType::Acknowledgment => {
+                            packet.body.on_receive(ack_queue.clone());
+                        }
+                        MessageType::Command => {
+                            packet.body.on_receive(command_queue.clone());
+                        }
+                        MessageType::Data => {
+                            packet.body.on_receive(data_queue.clone());
+                        }
+                        MessageType::Event => {
+                            packet.body.on_receive(event_queue.clone());
+                        }
+                        MessageType::Request => {
+                            packet.body.on_receive(request_queue.clone());
+                        }
+                        MessageType::Error => {
+                            packet.body.on_receive(error_queue.clone());
+                        }
+                        MessageType::Outgoing => {
+                            packet.body.on_receive(outgoing_queue.clone());
                         }
                     };
                     info!("packet received: {:?}", packet);
@@ -45,6 +87,13 @@ impl Actor for Mailbox {
 
         let addr = format!("127.0.0.1:{}", self.client_socket.clone());
         let addr_clone = addr.clone();
+        let ack_queue_clone = self.ack_queue.clone();
+        let command_queue_clone = self.ack_queue.clone();
+        let data_queue_clone = self.ack_queue.clone();
+        let event_queue_clone = self.ack_queue.clone();
+        let request_queue_clone = self.ack_queue.clone();
+        let error_queue_clone = self.ack_queue.clone();
+        let outgoing_queue_clone = self.ack_queue.clone();
         let fut = async move {
             match UdpSocket::bind(&addr).await {
                 Ok(sock) => {
@@ -53,7 +102,16 @@ impl Actor for Mailbox {
                     let sock = Arc::new(sock);
 
                     // Spawn a new Tokio task for reading from the socket
-                    tokio::spawn(Mailbox::start_udp_read(sock.clone()));
+                    tokio::spawn(Mailbox::start_udp_read(
+                        ack_queue_clone,
+                        command_queue_clone,
+                        data_queue_clone,
+                        event_queue_clone,
+                        request_queue_clone,
+                        error_queue_clone,
+                        outgoing_queue_clone,
+                        sock.clone(),
+                    ));
 
                     Ok(sock) // Return the socket wrapped in Arc
                 }

--- a/crates/session/src/session.rs
+++ b/crates/session/src/session.rs
@@ -4,6 +4,10 @@ use metaverse_login::models::login_response::LoginResult;
 use metaverse_login::models::simulator_login_protocol::Login;
 use metaverse_messages::models::circuit_code::CircuitCodeData;
 use metaverse_messages::models::packet::Packet;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 
 use std::error::Error;
 use tokio::time::{sleep, Duration};
@@ -23,27 +27,60 @@ pub async fn new_session(login_data: Login, login_url: String) -> Result<(), Box
         }
         Err(e) => return Err(format!("Login failed with unknown error, {}", e).into()),
     };
-
+    let ack_queue = Arc::new(Mutex::new(HashMap::new()));
+    let command_queue = Arc::new(Mutex::new(HashMap::new()));
+    let data_queue = Arc::new(Mutex::new(HashMap::new()));
+    let error_queue = Arc::new(Mutex::new(HashMap::new()));
+    let request_queue = Arc::new(Mutex::new(HashMap::new()));
+    let event_queue = Arc::new(Mutex::new(HashMap::new()));
+    let clone = ack_queue.clone();
     let mailbox = Mailbox {
         socket: None,
         url: login_response.sim_ip.unwrap(),
         server_socket: login_response.sim_port.unwrap(),
         client_socket: 41518, //TODO: Make this configurable
+        ack_queue: clone,
+        command_queue,
+        data_queue,
+        error_queue,
+        request_queue,
+        event_queue,
     }
     .start();
 
     let mut attempts = 0;
+    let mut received_ack = false;
 
     sleep(Duration::from_secs(2)).await;
 
-    while attempts < 3 {
+    while attempts < 3 && !received_ack {
+        let (tx, rx) = oneshot::channel();
+
+        {
+            let mut queue = ack_queue.lock().await;
+            queue.insert(1, tx);
+        }
+
         mailbox.do_send(Packet::new_circuit_code(CircuitCodeData {
             code: login_response.circuit_code,
             session_id: login_response.session_id.unwrap(),
             id: login_response.agent_id.unwrap(),
         }));
-        attempts += 1;
-        sleep(Duration::from_millis(500)).await;
+
+        tokio::select! {
+            _ = rx => {
+                received_ack = true; // Received acknowledgment
+            },
+            _ = sleep(Duration::from_millis(500)) => {
+                attempts += 1;
+                if !received_ack {
+                    {
+                        let mut queue = ack_queue.lock().await;
+                        queue.remove(&1);
+                    }
+                }
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
begins handling acks, and not spamming the login server unnecessarily. Jesus christ this code is a disaster, but I'm amazed that it works we're doing it, babey
now that acks are working, I have to investigate what the deal is with the id of the circuitcode being 1

next stop is generalizing this for packets that require acks, sending the CompleteAgentMovement packet, and sending the AgentUpdate packet. Once that is done our login will be fully up to spec