### PR TITLE
Adds agent update and fixes headers 

### DIFF
--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -12,6 +12,7 @@ metaverse_utils = { path = "../utils" }
 actix = "0.13.5"
 tokio = { version = "1.14.0", features = ["full"] }
 futures = "0.3"
+nalgebra = "0.30"
 [dependencies.uuid]
 version = "1.10.0"
 features = [

--- a/crates/messages/src/models/agent_update.rs
+++ b/crates/messages/src/models/agent_update.rs
@@ -1,0 +1,360 @@
+use std::sync::Arc;
+
+use nalgebra::Quaternion;
+use uuid::Uuid;
+
+use super::{header::{Header, PacketFrequency}, packet::{MessageType, Packet, PacketData}};
+
+const AGENT_STATE_TYPING: u8 = 0x04; // 00000100 in binary
+const AGENT_STATE_EDITING: u8 = 0x10; // 00010000 in binary
+
+const AGENT_CONTROL_AT_POS: u32 = 0x00000001;
+const AGENT_CONTROL_AT_NEG: u32 = 0x00000002;
+const AGENT_CONTROL_LEFT_POS: u32 = 0x00000004;
+const AGENT_CONTROL_LEFT_NEG: u32 = 0x00000008;
+const AGENT_CONTROL_UP_POS: u32 = 0x00000010;
+const AGENT_CONTROL_UP_NEG: u32 = 0x00000020;
+const AGENT_CONTROL_PITCH_POS: u32 = 0x00000040;
+const AGENT_CONTROL_PITCH_NEG: u32 = 0x00000080;
+const AGENT_CONTROL_YAW_POS: u32 = 0x00000100;
+const AGENT_CONTROL_YAW_NEG: u32 = 0x00000200;
+const AGENT_CONTROL_FAST_AT: u32 = 0x00000400;
+const AGENT_CONTROL_FAST_LEFT: u32 = 0x00000800;
+const AGENT_CONTROL_FAST_UP: u32 = 0x00001000;
+const AGENT_CONTROL_FLY: u32 = 0x00002000;
+const AGENT_CONTROL_STOP: u32 = 0x00004000;
+const AGENT_CONTROL_FINISH_ANIM: u32 = 0x00008000;
+const AGENT_CONTROL_STAND_UP: u32 = 0x00010000;
+const AGENT_CONTROL_SIT_ON_GROUND: u32 = 0x00020000;
+const AGENT_CONTROL_MOUSELOOK: u32 = 0x00040000;
+const AGENT_CONTROL_NUDGE_AT_POS: u32 = 0x00080000;
+const AGENT_CONTROL_NUDGE_AT_NEG: u32 = 0x00100000;
+const AGENT_CONTROL_NUDGE_LEFT_POS: u32 = 0x00200000;
+const AGENT_CONTROL_NUDGE_LEFT_NEG: u32 = 0x00400000;
+const AGENT_CONTROL_NUDGE_UP_POS: u32 = 0x00800000;
+const AGENT_CONTROL_NUDGE_UP_NEG: u32 = 0x01000000;
+const AGENT_CONTROL_TURN_LEFT: u32 = 0x02000000;
+const AGENT_CONTROL_TURN_RIGHT: u32 = 0x04000000;
+const AGENT_CONTROL_AWAY: u32 = 0x08000000;
+const AGENT_CONTROL_LBUTTON_DOWN: u32 = 0x10000000;
+const AGENT_CONTROL_LBUTTON_UP: u32 = 0x20000000;
+const AGENT_CONTROL_ML_LBUTTON_DOWN: u32 = 0x40000000;
+const AGENT_CONTROL_ML_LBUTTON_UP: u32 = 0x80000000;
+
+const AU_FLAGS_NONE: u8 = 0x00;
+const AU_FLAGS_HIDETITLE: u8 = 0x01;
+
+
+impl Packet{
+    pub fn new_agent_update(agent_update: AgentUpdate) -> Self {
+        Packet{
+            header: Header {
+                id: 4,
+                frequency: PacketFrequency::High,
+                reliable: false, 
+                sequence_number: 1, 
+                appended_acks: false,
+                zerocoded: false, 
+                resent: false, 
+                ack_list: None, 
+                size: None,
+            }, 
+            body: Arc::new(agent_update),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Vector3 {
+   pub x: f32, 
+   pub y: f32, 
+   pub z: f32
+}
+
+#[derive(Debug)]
+pub struct State {
+   pub typing: bool,
+   pub editing: bool
+}
+impl State {
+    pub fn from_bytes(bits: u8) -> Self {
+        Self {
+            typing: bits & AGENT_STATE_TYPING != 0,
+            editing: bits & AGENT_STATE_EDITING != 0,
+        }
+    }
+    pub fn to_bytes(&self) -> u8 {
+        let mut bits = 0u8;
+        if self.typing { bits |= AGENT_STATE_TYPING; }
+        if self.editing { bits |= AGENT_STATE_EDITING; }
+        bits
+    }
+}
+
+#[derive(Debug)]
+pub struct ControlFlags{
+  pub at_pos: bool,
+  pub at_neg: bool, 
+  pub left_pos: bool, 
+  pub left_neg: bool, 
+  pub up_pos: bool, 
+  pub up_neg: bool, 
+  pub pitch_pos: bool,
+  pub pitch_neg: bool, 
+  pub yaw_pos: bool,
+  pub yaw_neg: bool, 
+  pub fast_at: bool, 
+  pub fast_left: bool, 
+  pub fast_up: bool, 
+  pub fly: bool, 
+  pub stop: bool,
+  pub  finish_anim: bool,
+  pub  stand_up: bool, 
+  pub  sit_on_ground: bool, 
+  pub  mouselook: bool, 
+  pub  nudge_at_pos: bool, 
+  pub  nudge_at_neg: bool,
+  pub  nudge_left_pos: bool,
+  pub  nudge_left_neg: bool,
+  pub  nudge_up_pos: bool,
+  pub  nudge_up_neg: bool, 
+  pub  turn_left: bool, 
+  pub  turn_right: bool, 
+  pub  away: bool, 
+  pub  l_button_down: bool, 
+  pub  l_button_up: bool, 
+  pub  ml_button_down: bool, 
+  pub  ml_button_up: bool, 
+}
+impl ControlFlags {
+    pub fn from_bytes(bits: u32) -> Self {
+        Self {
+            at_pos: bits & AGENT_CONTROL_AT_POS != 0,
+            at_neg: bits & AGENT_CONTROL_AT_NEG != 0,
+            left_pos: bits & AGENT_CONTROL_LEFT_POS != 0,
+            left_neg: bits & AGENT_CONTROL_LEFT_NEG != 0,
+            up_pos: bits & AGENT_CONTROL_UP_POS != 0,
+            up_neg: bits & AGENT_CONTROL_UP_NEG != 0,
+            pitch_pos: bits & AGENT_CONTROL_PITCH_POS != 0,
+            pitch_neg: bits & AGENT_CONTROL_PITCH_NEG != 0,
+            yaw_pos: bits & AGENT_CONTROL_YAW_POS != 0,
+            yaw_neg: bits & AGENT_CONTROL_YAW_NEG != 0,
+            fast_at: bits & AGENT_CONTROL_FAST_AT != 0,
+            fast_left: bits & AGENT_CONTROL_FAST_LEFT != 0,
+            fast_up: bits & AGENT_CONTROL_FAST_UP != 0,
+            fly: bits & AGENT_CONTROL_FLY != 0,
+            stop: bits & AGENT_CONTROL_STOP != 0,
+            finish_anim: bits & AGENT_CONTROL_FINISH_ANIM != 0,
+            stand_up: bits & AGENT_CONTROL_STAND_UP != 0,
+            sit_on_ground: bits & AGENT_CONTROL_SIT_ON_GROUND != 0,
+            mouselook: bits & AGENT_CONTROL_MOUSELOOK != 0,
+            nudge_at_pos: bits & AGENT_CONTROL_NUDGE_AT_POS != 0,
+            nudge_at_neg: bits & AGENT_CONTROL_NUDGE_AT_NEG != 0,
+            nudge_left_pos: bits & AGENT_CONTROL_NUDGE_LEFT_POS != 0,
+            nudge_left_neg: bits & AGENT_CONTROL_NUDGE_LEFT_NEG != 0,
+            nudge_up_pos: bits & AGENT_CONTROL_NUDGE_UP_POS != 0,
+            nudge_up_neg: bits & AGENT_CONTROL_NUDGE_UP_NEG != 0,
+            turn_left: bits & AGENT_CONTROL_TURN_LEFT != 0,
+            turn_right: bits & AGENT_CONTROL_TURN_RIGHT != 0,
+            away: bits & AGENT_CONTROL_AWAY != 0,
+            l_button_down: bits & AGENT_CONTROL_LBUTTON_DOWN != 0,
+            l_button_up: bits & AGENT_CONTROL_LBUTTON_UP != 0,
+            ml_button_down: bits & AGENT_CONTROL_ML_LBUTTON_DOWN != 0,
+            ml_button_up: bits & AGENT_CONTROL_ML_LBUTTON_UP != 0,
+        }
+    }
+    pub fn to_bytes(&self) -> [u8; 4] {
+        let mut bits = 0u32;
+        if self.at_pos { bits |= AGENT_CONTROL_AT_POS; }
+        if self.at_neg { bits |= AGENT_CONTROL_AT_NEG; }
+        if self.left_pos { bits |= AGENT_CONTROL_LEFT_POS; }
+        if self.left_neg { bits |= AGENT_CONTROL_LEFT_NEG; }
+        if self.up_pos { bits |= AGENT_CONTROL_UP_POS; }
+        if self.up_neg { bits |= AGENT_CONTROL_UP_NEG; }
+        if self.pitch_pos { bits |= AGENT_CONTROL_PITCH_POS; }
+        if self.pitch_neg { bits |= AGENT_CONTROL_PITCH_NEG; }
+        if self.yaw_pos { bits |= AGENT_CONTROL_YAW_POS; }
+        if self.yaw_neg { bits |= AGENT_CONTROL_YAW_NEG; }
+        if self.fast_at { bits |= AGENT_CONTROL_FAST_AT; }
+        if self.fast_left { bits |= AGENT_CONTROL_FAST_LEFT; }
+        if self.fast_up { bits |= AGENT_CONTROL_FAST_UP; }
+        if self.fly { bits |= AGENT_CONTROL_FLY; }
+        if self.stop { bits |= AGENT_CONTROL_STOP; }
+        if self.finish_anim { bits |= AGENT_CONTROL_FINISH_ANIM; }
+        if self.stand_up { bits |= AGENT_CONTROL_STAND_UP; }
+        if self.sit_on_ground { bits |= AGENT_CONTROL_SIT_ON_GROUND; }
+        if self.mouselook { bits |= AGENT_CONTROL_MOUSELOOK; }
+        if self.nudge_at_pos { bits |= AGENT_CONTROL_NUDGE_AT_POS; }
+        if self.nudge_at_neg { bits |= AGENT_CONTROL_NUDGE_AT_NEG; }
+        if self.nudge_left_pos { bits |= AGENT_CONTROL_NUDGE_LEFT_POS; }
+        if self.nudge_left_neg { bits |= AGENT_CONTROL_NUDGE_LEFT_NEG; }
+        if self.nudge_up_pos { bits |= AGENT_CONTROL_NUDGE_UP_POS; }
+        if self.nudge_up_neg { bits |= AGENT_CONTROL_NUDGE_UP_NEG; }
+        if self.turn_left { bits |= AGENT_CONTROL_TURN_LEFT; }
+        if self.turn_right { bits |= AGENT_CONTROL_TURN_RIGHT; }
+        if self.away { bits |= AGENT_CONTROL_AWAY; }
+        if self.l_button_down { bits |= AGENT_CONTROL_LBUTTON_DOWN; }
+        if self.l_button_up { bits |= AGENT_CONTROL_LBUTTON_UP; }
+        if self.ml_button_down { bits |= AGENT_CONTROL_ML_LBUTTON_DOWN; }
+        if self.ml_button_up { bits |= AGENT_CONTROL_ML_LBUTTON_UP; }
+        bits.to_le_bytes()
+    }
+}
+
+#[derive(Debug)]
+pub struct Flags{
+   pub none: bool, 
+   pub hide_title: bool,
+}
+impl Flags {
+    pub fn from_bytes(bits: u8) -> Self {
+        Self {
+            none: bits & AU_FLAGS_NONE != 0,
+            hide_title: bits & AU_FLAGS_HIDETITLE != 0,
+        }
+    }
+    pub fn to_bytes(&self) -> u8 {
+        let mut bits = 0u8;
+        if self.none { bits |= AU_FLAGS_NONE; }
+        if self.hide_title { bits |= AU_FLAGS_HIDETITLE; }
+        bits
+    }
+}
+
+#[derive(Debug)]
+pub struct AgentUpdate {
+   pub agent_id: Uuid,
+   pub session_id: Uuid,
+   pub body_rotation: Quaternion<f32>,
+   pub head_rotation: Quaternion<f32>,
+   pub state: State, 
+   pub camera_center: Vector3,
+   pub camera_at_axis: Vector3, 
+   pub camera_left_axis: Vector3, 
+   pub camera_up_axis: Vector3, 
+   pub far: f32,
+   pub control_flags: ControlFlags,
+   pub flags: Flags 
+}
+
+pub trait ToFromBytes {
+    fn from_bytes(bytes: &[u8]) -> Self;
+    fn to_bytes(&self) -> [u8; 16];
+}
+
+impl ToFromBytes for Quaternion<f32> {
+    fn from_bytes(bytes: &[u8]) -> Self {
+        let x = f32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let y = f32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        let z = f32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        let w = f32::from_le_bytes(bytes[12..16].try_into().unwrap());
+        Quaternion::new(w, x, y, z)
+    }
+    fn to_bytes(&self) -> [u8; 16]{
+        let mut bytes = [0u8; 16];
+        bytes[0..4].copy_from_slice(&self.w.to_le_bytes());
+        bytes[4..8].copy_from_slice(&self.i.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.j.to_le_bytes());
+        bytes[12..16].copy_from_slice(&self.k.to_le_bytes());
+        bytes
+    }
+}
+
+impl PacketData for AgentUpdate {
+    fn from_bytes(bytes: &[u8]) -> std::io::Result<Self>{
+        let agent_id = Uuid::from_slice(&bytes[0..16]).unwrap();
+        let session_id = Uuid::from_slice(&bytes[16..32]).unwrap();
+        let body_rotation = Quaternion::from_bytes(&bytes[32..48]);
+        let head_rotation = Quaternion::from_bytes(&bytes[48..64]);
+
+        let state = State::from_bytes(bytes[64]);
+        let camera_center = Vector3{
+            x: f32::from_le_bytes(bytes[65..69].try_into().unwrap()),
+            y: f32::from_le_bytes(bytes[69..73].try_into().unwrap()),
+            z: f32::from_le_bytes(bytes[73..77].try_into().unwrap()),
+        };
+        let camera_at_axis = Vector3{
+            x: f32::from_le_bytes(bytes[77..81].try_into().unwrap()),
+            y: f32::from_le_bytes(bytes[81..85].try_into().unwrap()),
+            z: f32::from_le_bytes(bytes[85..89].try_into().unwrap()),
+        };
+        let camera_left_axis = Vector3{
+            x: f32::from_le_bytes(bytes[89..93].try_into().unwrap()),
+            y: f32::from_le_bytes(bytes[93..97].try_into().unwrap()),
+            z: f32::from_le_bytes(bytes[97..101].try_into().unwrap()),
+        };
+        let camera_up_axis = Vector3{
+            x: f32::from_le_bytes(bytes[101..105].try_into().unwrap()),
+            y: f32::from_le_bytes(bytes[105..109].try_into().unwrap()),
+            z: f32::from_le_bytes(bytes[109..113].try_into().unwrap()),
+        };
+        let far = f32::from_le_bytes(bytes[113..117].try_into().unwrap());
+        let control_flags = ControlFlags::from_bytes(u32::from_le_bytes(bytes[117..121].try_into().unwrap()));
+        let flags = Flags::from_bytes(bytes[121]);
+        Ok(Self {
+            agent_id,
+            session_id,
+            body_rotation,
+            head_rotation,
+            state,
+            camera_center,
+            camera_at_axis,
+            camera_left_axis,
+            camera_up_axis,
+            far,
+            control_flags,
+            flags,
+        })
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(121); // Total byte length
+
+        // Serialize UUIDs
+        bytes.extend_from_slice(self.agent_id.as_bytes());
+        bytes.extend_from_slice(self.session_id.as_bytes());
+
+        // Serialize Quaternions
+        bytes.extend_from_slice(&self.body_rotation.to_bytes());
+        bytes.extend_from_slice(&self.head_rotation.to_bytes());
+
+        // Serialize State
+        bytes.push(self.state.to_bytes());
+
+        // Serialize Vector3s
+        bytes.extend_from_slice(&self.camera_center.x.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_center.y.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_center.z.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_at_axis.x.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_at_axis.y.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_at_axis.z.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_left_axis.x.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_left_axis.y.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_left_axis.z.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_up_axis.x.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_up_axis.y.to_le_bytes());
+        bytes.extend_from_slice(&self.camera_up_axis.z.to_le_bytes());
+
+        bytes.extend_from_slice(&self.far.to_le_bytes());
+
+        bytes.extend_from_slice(&self.control_flags.to_bytes());
+
+        bytes.push(self.flags.to_bytes());
+
+        bytes        
+    }
+
+    fn on_receive(
+            &self,
+            _: Arc<tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>>,
+        ) -> futures::future::BoxFuture<'static, ()> {
+            Box::pin(async move {
+            // Implement the actual logic here later
+            println!("on_receive is not yet implemented.");
+        })
+    }
+
+    fn message_type(&self) -> super::packet::MessageType {
+        MessageType::Outgoing 
+    }
+}

--- a/crates/messages/src/models/agent_update.rs
+++ b/crates/messages/src/models/agent_update.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use nalgebra::Quaternion;
 use uuid::Uuid;
 
-use super::{header::{Header, PacketFrequency}, packet::{MessageType, Packet, PacketData}};
+use super::{
+    header::{Header, PacketFrequency},
+    packet::{MessageType, Packet, PacketData},
+};
 
 const AGENT_STATE_TYPING: u8 = 0x04; // 00000100 in binary
 const AGENT_STATE_EDITING: u8 = 0x10; // 00010000 in binary
@@ -44,21 +47,20 @@ const AGENT_CONTROL_ML_LBUTTON_UP: u32 = 0x80000000;
 const AU_FLAGS_NONE: u8 = 0x00;
 const AU_FLAGS_HIDETITLE: u8 = 0x01;
 
-
-impl Packet{
+impl Packet {
     pub fn new_agent_update(agent_update: AgentUpdate) -> Self {
-        Packet{
+        Packet {
             header: Header {
                 id: 4,
                 frequency: PacketFrequency::High,
-                reliable: false, 
-                sequence_number: 1, 
+                reliable: false,
+                sequence_number: 1,
                 appended_acks: false,
-                zerocoded: false, 
-                resent: false, 
-                ack_list: None, 
+                zerocoded: false,
+                resent: false,
+                ack_list: None,
                 size: None,
-            }, 
+            },
             body: Arc::new(agent_update),
         }
     }
@@ -66,15 +68,15 @@ impl Packet{
 
 #[derive(Debug)]
 pub struct Vector3 {
-   pub x: f32, 
-   pub y: f32, 
-   pub z: f32
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
 }
 
 #[derive(Debug)]
 pub struct State {
-   pub typing: bool,
-   pub editing: bool
+    pub typing: bool,
+    pub editing: bool,
 }
 impl State {
     pub fn from_bytes(bits: u8) -> Self {
@@ -85,46 +87,50 @@ impl State {
     }
     pub fn to_bytes(&self) -> u8 {
         let mut bits = 0u8;
-        if self.typing { bits |= AGENT_STATE_TYPING; }
-        if self.editing { bits |= AGENT_STATE_EDITING; }
+        if self.typing {
+            bits |= AGENT_STATE_TYPING;
+        }
+        if self.editing {
+            bits |= AGENT_STATE_EDITING;
+        }
         bits
     }
 }
 
 #[derive(Debug)]
-pub struct ControlFlags{
-  pub at_pos: bool,
-  pub at_neg: bool, 
-  pub left_pos: bool, 
-  pub left_neg: bool, 
-  pub up_pos: bool, 
-  pub up_neg: bool, 
-  pub pitch_pos: bool,
-  pub pitch_neg: bool, 
-  pub yaw_pos: bool,
-  pub yaw_neg: bool, 
-  pub fast_at: bool, 
-  pub fast_left: bool, 
-  pub fast_up: bool, 
-  pub fly: bool, 
-  pub stop: bool,
-  pub  finish_anim: bool,
-  pub  stand_up: bool, 
-  pub  sit_on_ground: bool, 
-  pub  mouselook: bool, 
-  pub  nudge_at_pos: bool, 
-  pub  nudge_at_neg: bool,
-  pub  nudge_left_pos: bool,
-  pub  nudge_left_neg: bool,
-  pub  nudge_up_pos: bool,
-  pub  nudge_up_neg: bool, 
-  pub  turn_left: bool, 
-  pub  turn_right: bool, 
-  pub  away: bool, 
-  pub  l_button_down: bool, 
-  pub  l_button_up: bool, 
-  pub  ml_button_down: bool, 
-  pub  ml_button_up: bool, 
+pub struct ControlFlags {
+    pub at_pos: bool,
+    pub at_neg: bool,
+    pub left_pos: bool,
+    pub left_neg: bool,
+    pub up_pos: bool,
+    pub up_neg: bool,
+    pub pitch_pos: bool,
+    pub pitch_neg: bool,
+    pub yaw_pos: bool,
+    pub yaw_neg: bool,
+    pub fast_at: bool,
+    pub fast_left: bool,
+    pub fast_up: bool,
+    pub fly: bool,
+    pub stop: bool,
+    pub finish_anim: bool,
+    pub stand_up: bool,
+    pub sit_on_ground: bool,
+    pub mouselook: bool,
+    pub nudge_at_pos: bool,
+    pub nudge_at_neg: bool,
+    pub nudge_left_pos: bool,
+    pub nudge_left_neg: bool,
+    pub nudge_up_pos: bool,
+    pub nudge_up_neg: bool,
+    pub turn_left: bool,
+    pub turn_right: bool,
+    pub away: bool,
+    pub l_button_down: bool,
+    pub l_button_up: bool,
+    pub ml_button_down: bool,
+    pub ml_button_up: bool,
 }
 impl ControlFlags {
     pub fn from_bytes(bits: u32) -> Self {
@@ -165,46 +171,110 @@ impl ControlFlags {
     }
     pub fn to_bytes(&self) -> [u8; 4] {
         let mut bits = 0u32;
-        if self.at_pos { bits |= AGENT_CONTROL_AT_POS; }
-        if self.at_neg { bits |= AGENT_CONTROL_AT_NEG; }
-        if self.left_pos { bits |= AGENT_CONTROL_LEFT_POS; }
-        if self.left_neg { bits |= AGENT_CONTROL_LEFT_NEG; }
-        if self.up_pos { bits |= AGENT_CONTROL_UP_POS; }
-        if self.up_neg { bits |= AGENT_CONTROL_UP_NEG; }
-        if self.pitch_pos { bits |= AGENT_CONTROL_PITCH_POS; }
-        if self.pitch_neg { bits |= AGENT_CONTROL_PITCH_NEG; }
-        if self.yaw_pos { bits |= AGENT_CONTROL_YAW_POS; }
-        if self.yaw_neg { bits |= AGENT_CONTROL_YAW_NEG; }
-        if self.fast_at { bits |= AGENT_CONTROL_FAST_AT; }
-        if self.fast_left { bits |= AGENT_CONTROL_FAST_LEFT; }
-        if self.fast_up { bits |= AGENT_CONTROL_FAST_UP; }
-        if self.fly { bits |= AGENT_CONTROL_FLY; }
-        if self.stop { bits |= AGENT_CONTROL_STOP; }
-        if self.finish_anim { bits |= AGENT_CONTROL_FINISH_ANIM; }
-        if self.stand_up { bits |= AGENT_CONTROL_STAND_UP; }
-        if self.sit_on_ground { bits |= AGENT_CONTROL_SIT_ON_GROUND; }
-        if self.mouselook { bits |= AGENT_CONTROL_MOUSELOOK; }
-        if self.nudge_at_pos { bits |= AGENT_CONTROL_NUDGE_AT_POS; }
-        if self.nudge_at_neg { bits |= AGENT_CONTROL_NUDGE_AT_NEG; }
-        if self.nudge_left_pos { bits |= AGENT_CONTROL_NUDGE_LEFT_POS; }
-        if self.nudge_left_neg { bits |= AGENT_CONTROL_NUDGE_LEFT_NEG; }
-        if self.nudge_up_pos { bits |= AGENT_CONTROL_NUDGE_UP_POS; }
-        if self.nudge_up_neg { bits |= AGENT_CONTROL_NUDGE_UP_NEG; }
-        if self.turn_left { bits |= AGENT_CONTROL_TURN_LEFT; }
-        if self.turn_right { bits |= AGENT_CONTROL_TURN_RIGHT; }
-        if self.away { bits |= AGENT_CONTROL_AWAY; }
-        if self.l_button_down { bits |= AGENT_CONTROL_LBUTTON_DOWN; }
-        if self.l_button_up { bits |= AGENT_CONTROL_LBUTTON_UP; }
-        if self.ml_button_down { bits |= AGENT_CONTROL_ML_LBUTTON_DOWN; }
-        if self.ml_button_up { bits |= AGENT_CONTROL_ML_LBUTTON_UP; }
+        if self.at_pos {
+            bits |= AGENT_CONTROL_AT_POS;
+        }
+        if self.at_neg {
+            bits |= AGENT_CONTROL_AT_NEG;
+        }
+        if self.left_pos {
+            bits |= AGENT_CONTROL_LEFT_POS;
+        }
+        if self.left_neg {
+            bits |= AGENT_CONTROL_LEFT_NEG;
+        }
+        if self.up_pos {
+            bits |= AGENT_CONTROL_UP_POS;
+        }
+        if self.up_neg {
+            bits |= AGENT_CONTROL_UP_NEG;
+        }
+        if self.pitch_pos {
+            bits |= AGENT_CONTROL_PITCH_POS;
+        }
+        if self.pitch_neg {
+            bits |= AGENT_CONTROL_PITCH_NEG;
+        }
+        if self.yaw_pos {
+            bits |= AGENT_CONTROL_YAW_POS;
+        }
+        if self.yaw_neg {
+            bits |= AGENT_CONTROL_YAW_NEG;
+        }
+        if self.fast_at {
+            bits |= AGENT_CONTROL_FAST_AT;
+        }
+        if self.fast_left {
+            bits |= AGENT_CONTROL_FAST_LEFT;
+        }
+        if self.fast_up {
+            bits |= AGENT_CONTROL_FAST_UP;
+        }
+        if self.fly {
+            bits |= AGENT_CONTROL_FLY;
+        }
+        if self.stop {
+            bits |= AGENT_CONTROL_STOP;
+        }
+        if self.finish_anim {
+            bits |= AGENT_CONTROL_FINISH_ANIM;
+        }
+        if self.stand_up {
+            bits |= AGENT_CONTROL_STAND_UP;
+        }
+        if self.sit_on_ground {
+            bits |= AGENT_CONTROL_SIT_ON_GROUND;
+        }
+        if self.mouselook {
+            bits |= AGENT_CONTROL_MOUSELOOK;
+        }
+        if self.nudge_at_pos {
+            bits |= AGENT_CONTROL_NUDGE_AT_POS;
+        }
+        if self.nudge_at_neg {
+            bits |= AGENT_CONTROL_NUDGE_AT_NEG;
+        }
+        if self.nudge_left_pos {
+            bits |= AGENT_CONTROL_NUDGE_LEFT_POS;
+        }
+        if self.nudge_left_neg {
+            bits |= AGENT_CONTROL_NUDGE_LEFT_NEG;
+        }
+        if self.nudge_up_pos {
+            bits |= AGENT_CONTROL_NUDGE_UP_POS;
+        }
+        if self.nudge_up_neg {
+            bits |= AGENT_CONTROL_NUDGE_UP_NEG;
+        }
+        if self.turn_left {
+            bits |= AGENT_CONTROL_TURN_LEFT;
+        }
+        if self.turn_right {
+            bits |= AGENT_CONTROL_TURN_RIGHT;
+        }
+        if self.away {
+            bits |= AGENT_CONTROL_AWAY;
+        }
+        if self.l_button_down {
+            bits |= AGENT_CONTROL_LBUTTON_DOWN;
+        }
+        if self.l_button_up {
+            bits |= AGENT_CONTROL_LBUTTON_UP;
+        }
+        if self.ml_button_down {
+            bits |= AGENT_CONTROL_ML_LBUTTON_DOWN;
+        }
+        if self.ml_button_up {
+            bits |= AGENT_CONTROL_ML_LBUTTON_UP;
+        }
         bits.to_le_bytes()
     }
 }
 
 #[derive(Debug)]
-pub struct Flags{
-   pub none: bool, 
-   pub hide_title: bool,
+pub struct Flags {
+    pub none: bool,
+    pub hide_title: bool,
 }
 impl Flags {
     pub fn from_bytes(bits: u8) -> Self {
@@ -215,26 +285,30 @@ impl Flags {
     }
     pub fn to_bytes(&self) -> u8 {
         let mut bits = 0u8;
-        if self.none { bits |= AU_FLAGS_NONE; }
-        if self.hide_title { bits |= AU_FLAGS_HIDETITLE; }
+        if self.none {
+            bits |= AU_FLAGS_NONE;
+        }
+        if self.hide_title {
+            bits |= AU_FLAGS_HIDETITLE;
+        }
         bits
     }
 }
 
 #[derive(Debug)]
 pub struct AgentUpdate {
-   pub agent_id: Uuid,
-   pub session_id: Uuid,
-   pub body_rotation: Quaternion<f32>,
-   pub head_rotation: Quaternion<f32>,
-   pub state: State, 
-   pub camera_center: Vector3,
-   pub camera_at_axis: Vector3, 
-   pub camera_left_axis: Vector3, 
-   pub camera_up_axis: Vector3, 
-   pub far: f32,
-   pub control_flags: ControlFlags,
-   pub flags: Flags 
+    pub agent_id: Uuid,
+    pub session_id: Uuid,
+    pub body_rotation: Quaternion<f32>,
+    pub head_rotation: Quaternion<f32>,
+    pub state: State,
+    pub camera_center: Vector3,
+    pub camera_at_axis: Vector3,
+    pub camera_left_axis: Vector3,
+    pub camera_up_axis: Vector3,
+    pub far: f32,
+    pub control_flags: ControlFlags,
+    pub flags: Flags,
 }
 
 pub trait ToFromBytes {
@@ -250,7 +324,7 @@ impl ToFromBytes for Quaternion<f32> {
         let w = f32::from_le_bytes(bytes[12..16].try_into().unwrap());
         Quaternion::new(w, x, y, z)
     }
-    fn to_bytes(&self) -> [u8; 16]{
+    fn to_bytes(&self) -> [u8; 16] {
         let mut bytes = [0u8; 16];
         bytes[0..4].copy_from_slice(&self.w.to_le_bytes());
         bytes[4..8].copy_from_slice(&self.i.to_le_bytes());
@@ -261,35 +335,36 @@ impl ToFromBytes for Quaternion<f32> {
 }
 
 impl PacketData for AgentUpdate {
-    fn from_bytes(bytes: &[u8]) -> std::io::Result<Self>{
+    fn from_bytes(bytes: &[u8]) -> std::io::Result<Self> {
         let agent_id = Uuid::from_slice(&bytes[0..16]).unwrap();
         let session_id = Uuid::from_slice(&bytes[16..32]).unwrap();
         let body_rotation = Quaternion::from_bytes(&bytes[32..48]);
         let head_rotation = Quaternion::from_bytes(&bytes[48..64]);
 
         let state = State::from_bytes(bytes[64]);
-        let camera_center = Vector3{
+        let camera_center = Vector3 {
             x: f32::from_le_bytes(bytes[65..69].try_into().unwrap()),
             y: f32::from_le_bytes(bytes[69..73].try_into().unwrap()),
             z: f32::from_le_bytes(bytes[73..77].try_into().unwrap()),
         };
-        let camera_at_axis = Vector3{
+        let camera_at_axis = Vector3 {
             x: f32::from_le_bytes(bytes[77..81].try_into().unwrap()),
             y: f32::from_le_bytes(bytes[81..85].try_into().unwrap()),
             z: f32::from_le_bytes(bytes[85..89].try_into().unwrap()),
         };
-        let camera_left_axis = Vector3{
+        let camera_left_axis = Vector3 {
             x: f32::from_le_bytes(bytes[89..93].try_into().unwrap()),
             y: f32::from_le_bytes(bytes[93..97].try_into().unwrap()),
             z: f32::from_le_bytes(bytes[97..101].try_into().unwrap()),
         };
-        let camera_up_axis = Vector3{
+        let camera_up_axis = Vector3 {
             x: f32::from_le_bytes(bytes[101..105].try_into().unwrap()),
             y: f32::from_le_bytes(bytes[105..109].try_into().unwrap()),
             z: f32::from_le_bytes(bytes[109..113].try_into().unwrap()),
         };
         let far = f32::from_le_bytes(bytes[113..117].try_into().unwrap());
-        let control_flags = ControlFlags::from_bytes(u32::from_le_bytes(bytes[117..121].try_into().unwrap()));
+        let control_flags =
+            ControlFlags::from_bytes(u32::from_le_bytes(bytes[117..121].try_into().unwrap()));
         let flags = Flags::from_bytes(bytes[121]);
         Ok(Self {
             agent_id,
@@ -341,20 +416,22 @@ impl PacketData for AgentUpdate {
 
         bytes.push(self.flags.to_bytes());
 
-        bytes        
+        bytes
     }
 
     fn on_receive(
-            &self,
-            _: Arc<tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>>,
-        ) -> futures::future::BoxFuture<'static, ()> {
-            Box::pin(async move {
+        &self,
+        _: Arc<
+            tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>,
+        >,
+    ) -> futures::future::BoxFuture<'static, ()> {
+        Box::pin(async move {
             // Implement the actual logic here later
             println!("on_receive is not yet implemented.");
         })
     }
 
     fn message_type(&self) -> super::packet::MessageType {
-        MessageType::Outgoing 
+        MessageType::Outgoing
     }
 }

--- a/crates/messages/src/models/complete_agent_movement.rs
+++ b/crates/messages/src/models/complete_agent_movement.rs
@@ -2,37 +2,41 @@ use std::sync::Arc;
 
 use uuid::Uuid;
 
-use super::{header::{Header, PacketFrequency}, packet::{MessageType, Packet, PacketData}};
+use super::{
+    header::{Header, PacketFrequency},
+    packet::{MessageType, Packet, PacketData},
+};
 
 impl Packet {
-    pub fn new_complete_agent_movement(complete_agent_movement_data: CompleteAgentMovementData) -> Self{
-        Packet{
+    pub fn new_complete_agent_movement(
+        complete_agent_movement_data: CompleteAgentMovementData,
+    ) -> Self {
+        Packet {
             header: Header {
                 id: 249,
                 frequency: PacketFrequency::Low,
-                reliable: false, 
+                reliable: false,
                 sequence_number: 3,
-                appended_acks: false, 
-                zerocoded: false, 
-                resent: false, 
+                appended_acks: false,
+                zerocoded: false,
+                resent: false,
                 ack_list: None,
                 size: None,
             },
             body: Arc::new(complete_agent_movement_data),
         }
-
     }
 }
 
 #[derive(Debug)]
-pub struct CompleteAgentMovementData{
+pub struct CompleteAgentMovementData {
     pub agent_id: Uuid,
     pub session_id: Uuid,
-    pub circuit_code: u32
+    pub circuit_code: u32,
 }
 
 impl PacketData for CompleteAgentMovementData {
-    fn from_bytes(bytes: &[u8]) -> std::io::Result<Self>{
+    fn from_bytes(bytes: &[u8]) -> std::io::Result<Self> {
         let circuit_code = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
         let session_id = Uuid::from_slice(&bytes[4..20]).unwrap();
         let agent_id = Uuid::from_slice(&bytes[20..36]).unwrap();
@@ -42,7 +46,6 @@ impl PacketData for CompleteAgentMovementData {
             session_id,
             circuit_code,
         })
-
     }
     fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(36);
@@ -52,14 +55,15 @@ impl PacketData for CompleteAgentMovementData {
         bytes
     }
     fn on_receive(
-            &self,
-            queue: Arc<tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>>,
-        ) -> futures::future::BoxFuture<'static, ()> {
+        &self,
+        queue: Arc<
+            tokio::sync::Mutex<std::collections::HashMap<u32, tokio::sync::oneshot::Sender<()>>>,
+        >,
+    ) -> futures::future::BoxFuture<'static, ()> {
         Box::pin(async move {
             // Implement the actual logic here later
             println!("on_receive is not yet implemented.");
         })
-        
     }
     fn message_type(&self) -> MessageType {
         MessageType::Outgoing

--- a/crates/messages/src/models/mod.rs
+++ b/crates/messages/src/models/mod.rs
@@ -1,9 +1,9 @@
+pub mod agent_update;
 pub mod circuit_code;
 pub mod coarse_location_update;
+pub mod complete_agent_movement;
 pub mod disable_simulator;
 pub mod header;
 pub mod packet;
 pub mod packet_ack;
 pub mod packet_types;
-pub mod complete_agent_movement;
-pub mod agent_update;

--- a/crates/messages/src/models/mod.rs
+++ b/crates/messages/src/models/mod.rs
@@ -6,3 +6,4 @@ pub mod packet;
 pub mod packet_ack;
 pub mod packet_types;
 pub mod complete_agent_movement;
+pub mod agent_update;

--- a/crates/session/src/models/mailbox.rs
+++ b/crates/session/src/models/mailbox.rs
@@ -37,10 +37,10 @@ impl Mailbox {
     ) {
         let mut buf = [0; 1024];
         loop {
-            info!("udp read is running");
             match sock.recv_from(&mut buf).await {
                 Ok((size, addr)) => {
                     info!("Received {} bytes from {:?}", size, addr);
+
                     let packet = match Packet::from_bytes(&buf[..size]) {
                         Ok(packet) => packet,
                         Err(e) => {

--- a/crates/session/src/session.rs
+++ b/crates/session/src/session.rs
@@ -63,9 +63,7 @@ pub async fn new_session(login_data: Login, login_url: String) -> Result<(), Box
         .await
     {
         Ok(_) => info!("circuit code sent and ack received"),
-        Err(e) => {
-            return Err(format!("Failed to create connection {}", e).into())
-        },
+        Err(e) => return Err(format!("Failed to create connection {}", e).into()),
     };
 
     match mailbox
@@ -81,12 +79,7 @@ pub async fn new_session(login_data: Login, login_url: String) -> Result<(), Box
         .await
     {
         Ok(_) => info!("complete agent movement sent and ack received"),
-        Err(e) => {
-            return Err(format!("Failed to complete agent movement: {}", e).into())
-        },
+        Err(e) => return Err(format!("Failed to complete agent movement: {}", e).into()),
     };
-
-
-
     Ok(())
 }

--- a/crates/session/tests/session.rs
+++ b/crates/session/tests/session.rs
@@ -107,7 +107,7 @@ async fn test_local() {
             Ok(_) => sleep(Duration::from_secs(3)).await,
             Err(e) => info!("sesion failed to start: {}", e),
         }
-
+        sleep(Duration::from_secs(10)).await;
         sim_server.do_send(CommandMessage {
             command: "quit".to_string(),
         });

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Data, DataEnum};
+use syn::{parse_macro_input, Data, DataEnum, DeriveInput};
 
 #[proc_macro_derive(IntoArc)]
 pub fn derive_into_arc(input: TokenStream) -> TokenStream {
@@ -34,4 +34,3 @@ pub fn derive_into_arc(input: TokenStream) -> TokenStream {
 
     TokenStream::from(expanded)
 }
-


### PR DESCRIPTION
headers weren't getting parsed correctly on a bunch of levels 
also discovered that there is a fourth type of frequency packet called Fixed, that was being ignored and parsed incorrectly in libopenmetaverse's implementation. 