### PR TITLE
gets async update read working in godot

### DIFF
--- a/crates/login/src/models/errors.rs
+++ b/crates/login/src/models/errors.rs
@@ -44,7 +44,11 @@ impl fmt::Display for LoginError {
         write!(f, "{}", err_msg)
     }
 }
-
+impl Error for LoginError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
 impl fmt::Debug for LoginError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/crates/messages/src/models/agent_update.rs
+++ b/crates/messages/src/models/agent_update.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::oneshot::Sender;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 
 use nalgebra::Quaternion;
 use uuid::Uuid;

--- a/crates/messages/src/models/circuit_code.rs
+++ b/crates/messages/src/models/circuit_code.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 use tokio::sync::oneshot::Sender;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 use uuid::Uuid;
 
 use super::client_update_data::ClientUpdateData;

--- a/crates/messages/src/models/client_update_data.rs
+++ b/crates/messages/src/models/client_update_data.rs
@@ -1,14 +1,51 @@
+use std::error::Error;
+use std::sync::Arc;
+
+use std::sync::Mutex;
+
 use super::packet::Packet;
 
-pub enum ClientUpdateContent {
-    Data(DataContent),
+pub enum ClientUpdateData {
+    String(String),
     Packet(Packet),
+    LoginProgress(LoginProgress),
+    Error(Box<dyn Error + Send + Sync>),
 }
 
-pub struct DataContent {
-    pub content: String,
+pub struct LoginProgress {
+    pub message: String,
+    pub percent: u8,
 }
 
-pub struct ClientUpdateData {
-    pub content: ClientUpdateContent,
+// Implement the From traits to make conversion easy
+impl From<String> for ClientUpdateData {
+    fn from(value: String) -> Self {
+        ClientUpdateData::String(value)
+    }
+}
+
+impl From<Packet> for ClientUpdateData {
+    fn from(value: Packet) -> Self {
+        ClientUpdateData::Packet(value)
+    }
+}
+
+impl From<LoginProgress> for ClientUpdateData {
+    fn from(value: LoginProgress) -> Self {
+        ClientUpdateData::LoginProgress(value)
+    }
+}
+
+impl From<Box<dyn Error + Send + Sync>> for ClientUpdateData {
+    fn from(value: Box<dyn Error + Send + Sync>) -> Self {
+        ClientUpdateData::Error(value)
+    }
+}
+
+pub async fn send_message_to_client(
+    stream: Arc<Mutex<Vec<ClientUpdateData>>>,
+    content: ClientUpdateData,
+) {
+    let mut stream = stream.lock().unwrap();
+    stream.push(content);
 }

--- a/crates/messages/src/models/coarse_location_update.rs
+++ b/crates/messages/src/models/coarse_location_update.rs
@@ -10,7 +10,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::oneshot::Sender;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 
 /// ID: 6
 /// Frequency: Medium

--- a/crates/messages/src/models/complete_agent_movement.rs
+++ b/crates/messages/src/models/complete_agent_movement.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::{oneshot::Sender, Mutex};
-
+use tokio::sync::oneshot::Sender;
+use std::sync::Mutex;
 use uuid::Uuid;
 
 use super::{

--- a/crates/messages/src/models/disable_simulator.rs
+++ b/crates/messages/src/models/disable_simulator.rs
@@ -5,7 +5,7 @@ use super::{
 use futures::future::BoxFuture;
 use std::{collections::HashMap, io, sync::Arc};
 use tokio::sync::oneshot::Sender;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 
 // ID: 152
 // Frequency: Low

--- a/crates/messages/src/models/packet.rs
+++ b/crates/messages/src/models/packet.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 use tokio::sync::oneshot::Sender;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 
 use super::client_update_data::ClientUpdateData;
 use super::packet_types::PacketType;

--- a/crates/messages/src/models/packet_ack.rs
+++ b/crates/messages/src/models/packet_ack.rs
@@ -9,7 +9,8 @@ use std::{
     io::{self, Cursor},
     sync::Arc,
 };
-use tokio::sync::{oneshot::Sender, Mutex};
+use tokio::sync::oneshot::Sender;
+use std::sync::Mutex;
 
 // ID: 65531
 // Frequency: Low
@@ -54,7 +55,7 @@ impl PacketData for PacketAck {
         let packet_ids = self.packet_ids.clone();
 
         Box::pin(async move {
-            let mut queue = ack_queue.lock().await;
+            let mut queue = ack_queue.lock().unwrap();
             for id in packet_ids {
                 if let Some(sender) = queue.remove(&id) {
                     let _ = sender.send(());

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -10,8 +10,8 @@ license = "AGPL-3.0-or-later"
 
 [dependencies]
 config = "0.11"
-metaverse_messages = "0.0.1"
-metaverse_login = "0.1.2"
+metaverse_messages = {path = "../messages/"}
+metaverse_login = {path = "../login/"}
 metaverse_instantiator = "0.0.4"
 xmlrpc = "0.15.1"
 actix-web = "3"
@@ -23,6 +23,7 @@ actix = "0.13.5"
 hex = "0.4"
 rand = "0.8"
 futures = "0.3.30"
+thiserror = "1.0.63"
 
 actix-rt = "2.7"
 [dependencies.uuid]

--- a/crates/session/src/models/errors.rs
+++ b/crates/session/src/models/errors.rs
@@ -1,5 +1,5 @@
 use metaverse_login::models::errors::LoginError;
-use std::fmt;
+use std::{error::Error, fmt};
 
 #[derive(Clone, Debug)]
 pub enum SessionError {
@@ -29,6 +29,28 @@ impl fmt::Display for SessionError {
     }
 }
 
+impl Error for SessionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            SessionError::CircuitCode(err) => Some(err),
+            SessionError::Login(err) => Some(err),
+            SessionError::CompleteAgentMovement(err) => Some(err),
+        }
+    }
+}
+
+impl SessionError {
+    pub fn as_boxed_error(&self) -> Box<dyn Error + Send + Sync> {
+        match self {
+            SessionError::CircuitCode(err) => Box::new(err.clone()) as Box<dyn Error + Send + Sync>,
+            SessionError::Login(err) => Box::new(err.clone()) as Box<dyn Error + Send + Sync>,
+            SessionError::CompleteAgentMovement(err) => {
+                Box::new(err.clone()) as Box<dyn Error + Send + Sync>
+            } // Add other error types here
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum SendFailReason {
     Timeout,
@@ -54,6 +76,11 @@ impl fmt::Display for CircuitCodeError {
         write!(f, "{}", self.reason)
     }
 }
+impl Error for CircuitCodeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
 
 impl CircuitCodeError {
     pub fn new(reason: SendFailReason, message: String) -> Self {
@@ -75,5 +102,10 @@ impl CompleteAgentMovementError {
 impl fmt::Display for CompleteAgentMovementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.reason)
+    }
+}
+impl Error for CompleteAgentMovementError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
     }
 }

--- a/crates/session/src/models/mailbox.rs
+++ b/crates/session/src/models/mailbox.rs
@@ -1,16 +1,14 @@
 use actix::prelude::*;
 use futures::future::BoxFuture;
 use log::{error, info};
-use metaverse_messages::models::client_update_data::{
-    ClientUpdateContent, ClientUpdateData, DataContent,
-};
+use metaverse_messages::models::client_update_data::ClientUpdateData;
 use metaverse_messages::models::packet::{MessageType, Packet};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
 use tokio::sync::oneshot;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 use tokio::time::sleep;
 
 pub struct Mailbox {
@@ -217,7 +215,7 @@ impl AllowAcks for Addr<Mailbox> {
 
                 // these brackets make a new scope so the queue is opened and closed inside them
                 {
-                    let mut queue = ack_queue.lock().await;
+                    let mut queue = ack_queue.lock().unwrap();
                     queue.insert(packet_id, tx);
                 }
                 // Send the packet
@@ -231,7 +229,7 @@ impl AllowAcks for Addr<Mailbox> {
                         println!("Attempt {} failed to receive acknowledgment", attempts);
                         if !received_ack {
                             {
-                                let mut queue = ack_queue.lock().await;
+                                let mut queue = ack_queue.lock().unwrap();
                                 queue.remove(&1);
                             }
                         }

--- a/crates/session/src/session.rs
+++ b/crates/session/src/session.rs
@@ -4,14 +4,13 @@ use metaverse_login::login::{self};
 use metaverse_login::models::errors::{LoginError, Reason};
 use metaverse_login::models::simulator_login_protocol::{Login, SimulatorLoginProtocol};
 use metaverse_messages::models::circuit_code::CircuitCodeData;
-use metaverse_messages::models::client_update_data::{
-    ClientUpdateContent, ClientUpdateData, DataContent,
-};
+use metaverse_messages::models::client_update_data::send_message_to_client;
+use metaverse_messages::models::client_update_data::{ClientUpdateData, LoginProgress};
 use metaverse_messages::models::complete_agent_movement::CompleteAgentMovementData;
 use metaverse_messages::models::packet::Packet;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 
 use tokio::time::Duration;
 
@@ -31,21 +30,50 @@ impl Session {
         login_url: String,
         update_stream: Arc<Mutex<Vec<ClientUpdateData>>>,
     ) -> Result<Self, SessionError> {
+        send_message_to_client(
+            update_stream.clone(),
+            LoginProgress {
+                message: "Sending login xml".to_string(),
+                percent: 5,
+            }
+            .into(),
+        )
+        .await;
+
         let login_url_clone = login_url.clone();
         let login_result = tokio::task::spawn_blocking(|| {
             login::login(SimulatorLoginProtocol::new(login_data), login_url_clone)
         });
 
+        let update_stream_clone = update_stream.clone();
         let login_response = match login_result.await {
-            Ok(Ok(response)) => response,
-            Ok(Err(e)) => return Err(SessionError::new_login_error(e)),
+            Ok(Ok(response)) => {
+                send_message_to_client(
+                    update_stream_clone,
+                    LoginProgress {
+                        message: "Login xml sent successfully".to_string(),
+                        percent: 10,
+                    }
+                    .into(),
+                )
+                .await;
+                response
+            }
+            Ok(Err(e)) => {
+                let error = SessionError::new_login_error(e);
+                send_message_to_client(update_stream, error.as_boxed_error().into()).await;
+                return Err(error);
+            }
             Err(e) => {
-                return Err(SessionError::new_login_error(LoginError::new(
+                let error = SessionError::new_login_error(LoginError::new(
                     Reason::Unknown,
                     &format!("join error: {}", e),
-                )))
+                ));
+                send_message_to_client(update_stream, error.as_boxed_error().into()).await;
+                return Err(error);
             }
         };
+
         let ack_queue = Arc::new(Mutex::new(HashMap::new()));
         let command_queue = Arc::new(Mutex::new(HashMap::new()));
         let data_queue = Arc::new(Mutex::new(HashMap::new()));
@@ -59,7 +87,16 @@ impl Session {
         let event_queue_clone = event_queue.clone();
         let ack_queue_clone = ack_queue.clone();
         let update_stream_clone = update_stream.clone();
-        
+
+        send_message_to_client(
+            update_stream.clone(),
+            LoginProgress {
+                message: "Starting packet mailbox".to_string(),
+                percent: 25,
+            }
+            .into(),
+        )
+        .await;
         let mailbox = Mailbox {
             socket: None,
             url: login_response.sim_ip.unwrap(),
@@ -74,7 +111,25 @@ impl Session {
             update_stream: update_stream_clone,
         }
         .start();
-        
+
+        send_message_to_client(
+            update_stream.clone(),
+            LoginProgress {
+                message: "Packet mailbox started".to_string(),
+                percent: 40,
+            }
+            .into(),
+        )
+        .await;
+        send_message_to_client(
+            update_stream.clone(),
+            LoginProgress {
+                message: "Sending use circuit code packet".to_string(),
+                percent: 55,
+            }
+            .into(),
+        )
+        .await;
         match mailbox
             .send_with_ack(
                 Packet::new_circuit_code(CircuitCodeData {
@@ -87,31 +142,78 @@ impl Session {
             )
             .await
         {
-            Ok(_) => info!("circuit code sent and ack received"),
+            Ok(_) => {
+                send_message_to_client(
+                    update_stream.clone(),
+                    LoginProgress {
+                        message: "Circuit code sent and server ack received".to_string(),
+                        percent: 60,
+                    }
+                    .into(),
+                )
+                .await;
+                info!("circuit code sent and ack received");
+            }
             Err(e) => {
-                return Err(SessionError::CircuitCode(CircuitCodeError::new(
+                let error = SessionError::CircuitCode(CircuitCodeError::new(
                     SendFailReason::Timeout,
                     format!("{}", e),
-                )))
+                ));
+                send_message_to_client(update_stream, error.as_boxed_error().into()).await;
+                return Err(error);
             }
         };
+        send_message_to_client(
+            update_stream.clone(),
+            LoginProgress {
+                message: "Sending complete agent movement data packet".to_string(),
+                percent: 75,
+            }
+            .into(),
+        )
+        .await;
+
         match mailbox
-            .send(
-                Packet::new_complete_agent_movement(CompleteAgentMovementData {
+            .send(Packet::new_complete_agent_movement(
+                CompleteAgentMovementData {
                     circuit_code: login_response.circuit_code,
                     session_id: login_response.session_id.unwrap(),
                     agent_id: login_response.agent_id.unwrap(),
-                }),
-            )
+                },
+            ))
             .await
         {
-            Ok(_) => info!("complete agent movement sent"),
+            Ok(_) => {
+                send_message_to_client(
+                    update_stream.clone(),
+                    LoginProgress {
+                        message: "Complete agent movement sent".to_string(),
+                        percent: 90,
+                    }
+                    .into(),
+                )
+                .await;
+                info!("Complete agent movement sent");
+            }
             Err(e) => {
-                return Err(SessionError::CompleteAgentMovement(
-                    CompleteAgentMovementError::new(SendFailReason::Timeout, format!("{}", e)),
-                ))
+                let error = SessionError::CompleteAgentMovement(CompleteAgentMovementError::new(
+                    SendFailReason::Timeout,
+                    format!("{}", e),
+                ));
+                send_message_to_client(update_stream, error.as_boxed_error().into()).await;
+                return Err(error);
             }
         };
+                send_message_to_client(
+                    update_stream.clone(),
+                    LoginProgress {
+                        message: "Login complete!".to_string(),
+                        percent: 100,
+                    }
+                    .into(),
+                )
+                .await;
+ 
         Ok(Session {
             mailbox,
             update_stream,


### PR DESCRIPTION
this allows for spawning the read async in godot. This is going to allow for the creation of a loading bar for logins. However, things are still busted. this is not fully functional. 

needed to change all of the tokio mutexes to regular ones 
be sure to go back and deal with the unsafe unwrap() you're doing, because that is sure to start a fire 

also makes client update data more functional and updates several other error types