### PR TITLE
implements chat

### DIFF
--- a/crates/messages/src/models/agent_update.rs
+++ b/crates/messages/src/models/agent_update.rs
@@ -1,6 +1,6 @@
+use std::sync::Mutex;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::oneshot::Sender;
-use std::sync::Mutex;
 
 use nalgebra::Quaternion;
 use uuid::Uuid;
@@ -69,7 +69,7 @@ impl Packet {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Vector3 {
     pub x: f32,
     pub y: f32,

--- a/crates/messages/src/models/chat_from_simulator.rs
+++ b/crates/messages/src/models/chat_from_simulator.rs
@@ -1,0 +1,254 @@
+use super::{
+    agent_update::Vector3,
+    client_update_data::{send_message_to_client, ClientUpdateData},
+    header::Header,
+    packet::{MessageType, Packet, PacketData},
+};
+use byteorder::ReadBytesExt;
+use futures::future::BoxFuture;
+use std::{
+    collections::HashMap,
+    io::{self, BufRead, Cursor},
+    sync::Arc,
+};
+use std::{io::Read, sync::Mutex};
+use tokio::sync::oneshot::Sender;
+use tokio::task;
+use tokio::task::spawn_blocking;
+use uuid::Uuid;
+
+// ID: 139
+// Frequency: Low
+
+impl Packet {
+    pub fn new_chat_from_simulator(chat_from_simulator: ChatFromSimulator) -> Self {
+        Packet {
+            header: Header {
+                id: 139,
+                frequency: super::header::PacketFrequency::Low,
+                reliable: false,
+                sequence_number: 3,
+                appended_acks: false,
+                zerocoded: false,
+                resent: false,
+                ack_list: None,
+                size: None,
+            },
+            body: Arc::new(chat_from_simulator),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatFromSimulator {
+    pub from_name: String,
+    pub source_id: Uuid,
+    pub owner_id: Uuid,
+    pub source_type: SourceType,
+    pub chat_type: ChatType,
+    pub audible: Audible,
+    pub position: Vector3,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum SourceType {
+    System,
+    Agent,
+    Object,
+    Unknown,
+}
+impl SourceType {
+    fn from_bytes(bytes: u8) -> Self {
+        match bytes {
+            0 => SourceType::System,
+            1 => SourceType::Agent,
+            2 => SourceType::Object,
+            _ => SourceType::Unknown,
+        }
+    }
+    fn to_bytes(&self) -> u8 {
+        match self {
+            SourceType::System => 0,
+            SourceType::Agent => 1,
+            SourceType::Object => 2,
+            SourceType::Unknown => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Audible {
+    Not,
+    Barely,
+    Fully,
+    Unknown,
+}
+impl Audible {
+    fn from_bytes(bytes: u8) -> Self {
+        match bytes {
+            255 => Audible::Not,
+            0 => Audible::Barely,
+            1 => Audible::Fully,
+            _ => Audible::Unknown,
+        }
+    }
+    fn to_bytes(&self) -> u8 {
+        match self {
+            Audible::Not => 255,
+            Audible::Barely => 0,
+            Audible::Fully => 1,
+            Audible::Unknown => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ChatType {
+    Whisper,
+    Normal,
+    Shout,
+    Say,
+    StartTyping,
+    StopTyping,
+    Debug,
+    OwnerSay,
+    Unknown,
+}
+impl ChatType {
+    fn from_bytes(bytes: u8) -> Self {
+        match bytes {
+            0 => ChatType::Whisper,
+            1 => ChatType::Normal,
+            2 => ChatType::Shout,
+            3 => ChatType::Say,
+            4 => ChatType::StartTyping,
+            5 => ChatType::StopTyping,
+            6 => ChatType::Debug,
+            8 => ChatType::OwnerSay,
+            _ => ChatType::Unknown,
+        }
+    }
+    fn to_bytes(&self) -> u8 {
+        match self {
+            ChatType::Whisper => 0,
+            ChatType::Normal => 1,
+            ChatType::Shout => 2,
+            ChatType::Say => 3,
+            ChatType::StartTyping => 4,
+            ChatType::StopTyping => 5,
+            ChatType::Debug => 6,
+            ChatType::OwnerSay => 8,
+            ChatType::Unknown => 9,
+        }
+    }
+}
+
+impl PacketData for ChatFromSimulator {
+    fn from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        let mut cursor = Cursor::new(bytes);
+
+        // FromName
+        let mut from_name_bytes = Vec::new();
+        cursor.read_until(0, &mut from_name_bytes)?; // Read until null terminator
+        let from_name =
+            String::from_utf8(from_name_bytes.into_iter().filter(|&b| b != 0).collect())
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        // SourceID
+        let source_id = Uuid::from_slice(
+            &cursor.get_ref()[cursor.position() as usize..cursor.position() as usize + 16],
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        cursor.set_position(cursor.position() + 16);
+
+        // OwnerID
+        let owner_id = Uuid::from_slice(
+            &cursor.get_ref()[cursor.position() as usize..cursor.position() as usize + 16],
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        cursor.set_position(cursor.position() + 16);
+
+        // SourceType
+        let source_type_byte = cursor.read_u8()?;
+        let source_type = SourceType::from_bytes(source_type_byte);
+
+        // ChatType
+        let chat_type_byte = cursor.read_u8()?;
+        let chat_type = ChatType::from_bytes(chat_type_byte);
+
+        // Audible
+        let audible_byte = cursor.read_u8()?;
+        let audible = Audible::from_bytes(audible_byte);
+
+        // Position (LLVector3)
+        let position = Vector3 {
+            x: cursor.read_f32::<byteorder::LittleEndian>()?,
+            y: cursor.read_f32::<byteorder::LittleEndian>()?,
+            z: cursor.read_f32::<byteorder::LittleEndian>()?,
+        };
+
+        // Message
+        let mut message_bytes = Vec::new();
+        cursor.read_to_end(&mut message_bytes)?;
+        let message = String::from_utf8(message_bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        Ok(Self {
+            from_name,
+            source_id,
+            owner_id,
+            source_type,
+            chat_type,
+            audible,
+            position,
+            message,
+        })
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        // Convert `from_name` to bytes (length-prefixed)
+        let name_bytes = self.from_name.as_bytes();
+        bytes.extend_from_slice(&(name_bytes.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(name_bytes);
+
+        // Convert `source_id` and `owner_id` to bytes
+        bytes.extend_from_slice(self.source_id.as_bytes());
+        bytes.extend_from_slice(self.owner_id.as_bytes());
+
+        // Convert `source_type`, `chat_type`, and `audible` to bytes
+        bytes.push(self.source_type.to_bytes());
+        bytes.push(self.chat_type.to_bytes());
+        bytes.push(self.audible.to_bytes());
+
+        // Convert `position` (Vector3<f32>) to bytes
+        bytes.extend_from_slice(&self.position.x.to_le_bytes());
+        bytes.extend_from_slice(&self.position.y.to_le_bytes());
+        bytes.extend_from_slice(&self.position.z.to_le_bytes());
+
+        // Convert `message` to bytes (length-prefixed)
+        let message_bytes = self.message.as_bytes();
+        bytes.extend_from_slice(&(message_bytes.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(message_bytes);
+
+        bytes
+    }
+
+    fn on_receive(
+        &self,
+        _: Arc<Mutex<HashMap<u32, Sender<()>>>>,
+        client_update: Arc<Mutex<Vec<ClientUpdateData>>>,
+    ) -> BoxFuture<'static, ()> {
+        let chat_data: ClientUpdateData = ClientUpdateData::ChatFromSimulator(self.clone());
+
+        Box::pin(async move {
+            send_message_to_client(client_update.clone(), chat_data).await
+        })
+    }
+
+    fn message_type(&self) -> MessageType {
+        MessageType::Event
+    }
+}

--- a/crates/messages/src/models/circuit_code.rs
+++ b/crates/messages/src/models/circuit_code.rs
@@ -4,8 +4,8 @@ use futures::future::BoxFuture;
 use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
-use tokio::sync::oneshot::Sender;
 use std::sync::Mutex;
+use tokio::sync::oneshot::Sender;
 use uuid::Uuid;
 
 use super::client_update_data::ClientUpdateData;

--- a/crates/messages/src/models/client_update_data.rs
+++ b/crates/messages/src/models/client_update_data.rs
@@ -3,15 +3,19 @@ use std::sync::Arc;
 
 use std::sync::Mutex;
 
+use super::chat_from_simulator::ChatFromSimulator;
 use super::packet::Packet;
 
+#[derive(Debug)]
 pub enum ClientUpdateData {
     String(String),
     Packet(Packet),
     LoginProgress(LoginProgress),
     Error(Box<dyn Error + Send + Sync>),
+    ChatFromSimulator(ChatFromSimulator),
 }
 
+#[derive(Debug)]
 pub struct LoginProgress {
     pub message: String,
     pub percent: u8,
@@ -42,6 +46,11 @@ impl From<Box<dyn Error + Send + Sync>> for ClientUpdateData {
     }
 }
 
+impl From<ChatFromSimulator> for ClientUpdateData {
+    fn from(value: ChatFromSimulator) -> Self {
+        ClientUpdateData::ChatFromSimulator(value)
+    }
+}
 pub async fn send_message_to_client(
     stream: Arc<Mutex<Vec<ClientUpdateData>>>,
     content: ClientUpdateData,

--- a/crates/messages/src/models/coarse_location_update.rs
+++ b/crates/messages/src/models/coarse_location_update.rs
@@ -4,13 +4,13 @@ use super::{
 };
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use futures::future::BoxFuture;
+use std::sync::Mutex;
 use std::{
     collections::HashMap,
     io::{self, Cursor, Write},
     sync::Arc,
 };
 use tokio::sync::oneshot::Sender;
-use std::sync::Mutex;
 
 /// ID: 6
 /// Frequency: Medium

--- a/crates/messages/src/models/complete_agent_movement.rs
+++ b/crates/messages/src/models/complete_agent_movement.rs
@@ -1,6 +1,6 @@
+use std::sync::Mutex;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::oneshot::Sender;
-use std::sync::Mutex;
 use uuid::Uuid;
 
 use super::{

--- a/crates/messages/src/models/disable_simulator.rs
+++ b/crates/messages/src/models/disable_simulator.rs
@@ -3,9 +3,9 @@ use super::{
     packet::{MessageType, PacketData},
 };
 use futures::future::BoxFuture;
+use std::sync::Mutex;
 use std::{collections::HashMap, io, sync::Arc};
 use tokio::sync::oneshot::Sender;
-use std::sync::Mutex;
 
 // ID: 152
 // Frequency: Low

--- a/crates/messages/src/models/mod.rs
+++ b/crates/messages/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_update;
+pub mod chat_from_simulator;
 pub mod circuit_code;
 pub mod client_update_data;
 pub mod coarse_location_update;

--- a/crates/messages/src/models/packet.rs
+++ b/crates/messages/src/models/packet.rs
@@ -4,8 +4,8 @@ use futures::future::BoxFuture;
 use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
-use tokio::sync::oneshot::Sender;
 use std::sync::Mutex;
+use tokio::sync::oneshot::Sender;
 
 use super::client_update_data::ClientUpdateData;
 use super::packet_types::PacketType;

--- a/crates/messages/src/models/packet_ack.rs
+++ b/crates/messages/src/models/packet_ack.rs
@@ -4,13 +4,13 @@ use super::{
 };
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use futures::future::BoxFuture;
+use std::sync::Mutex;
 use std::{
     collections::HashMap,
     io::{self, Cursor},
     sync::Arc,
 };
 use tokio::sync::oneshot::Sender;
-use std::sync::Mutex;
 
 // ID: 65531
 // Frequency: Low

--- a/crates/messages/src/models/packet_types.rs
+++ b/crates/messages/src/models/packet_types.rs
@@ -1,4 +1,5 @@
 use super::agent_update::AgentUpdate;
+use super::chat_from_simulator::ChatFromSimulator;
 use super::complete_agent_movement::CompleteAgentMovementData;
 use super::{
     circuit_code::CircuitCodeData, coarse_location_update::CoarseLocationUpdate,
@@ -21,6 +22,7 @@ pub enum PacketType {
     CoarseLocationUpdate(Box<dyn PacketData>),
     CompleteAgentMovementData(Box<dyn PacketData>),
     AgentUpdate(Box<dyn PacketData>),
+    ChatFromSimulator(Box<dyn PacketData>),
 }
 
 impl PacketType {
@@ -61,6 +63,9 @@ impl PacketType {
                 ))),
                 249 => Ok(PacketType::CompleteAgentMovementData(Box::new(
                     CompleteAgentMovementData::from_bytes(bytes)?,
+                ))),
+                139 => Ok(PacketType::ChatFromSimulator(Box::new(
+                    ChatFromSimulator::from_bytes(bytes)?,
                 ))),
                 id => Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/crates/session/src/models/mailbox.rs
+++ b/crates/session/src/models/mailbox.rs
@@ -1,14 +1,14 @@
 use actix::prelude::*;
 use futures::future::BoxFuture;
 use log::{error, info};
-use metaverse_messages::models::client_update_data::ClientUpdateData;
+use metaverse_messages::models::client_update_data::{send_message_to_client, ClientUpdateData};
 use metaverse_messages::models::packet::{MessageType, Packet};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 use tokio::net::UdpSocket;
 use tokio::sync::oneshot;
-use std::sync::Mutex;
 use tokio::time::sleep;
 
 pub struct Mailbox {
@@ -142,7 +142,6 @@ impl Actor for Mailbox {
                         update_stream_clone,
                         sock.clone(),
                     ));
-
                     Ok(sock) // Return the socket wrapped in Arc
                 }
                 Err(e) => {

--- a/crates/session/src/session.rs
+++ b/crates/session/src/session.rs
@@ -11,6 +11,7 @@ use metaverse_messages::models::packet::Packet;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::thread; 
 
 use tokio::time::Duration;
 
@@ -204,16 +205,16 @@ impl Session {
                 return Err(error);
             }
         };
-                send_message_to_client(
-                    update_stream.clone(),
-                    LoginProgress {
-                        message: "Login complete!".to_string(),
-                        percent: 100,
-                    }
-                    .into(),
-                )
-                .await;
- 
+        send_message_to_client(
+            update_stream.clone(),
+            LoginProgress {
+                message: "Login complete!".to_string(),
+                percent: 100,
+            }
+            .into(),
+        )
+        .await;
+
         Ok(Session {
             mailbox,
             update_stream,


### PR DESCRIPTION
allows packets of type chat_from_simulator to be parsed may need some tweaking, but the bare bones works

Right now the username is getting parsed like " \u{e}default2 user", and the message is getting parsed like "\u{5}\0hewo\0" 

these \u 's and \0's should probably not be there when things get displayed.