### PR TITLE
Fixes acks

### DIFF
--- a/crates/chat/src/main.rs
+++ b/crates/chat/src/main.rs
@@ -108,16 +108,16 @@ fn main() {
                 println!("Goodbye!");
                 break; // Exit the loop if the user types "quit"
             }
+            sleep(Duration::from_secs(1)).await;
             match session
                 .mailbox
-                .send(
-                    Packet::new_chat_from_viewer(ChatFromViewer {
-                        agent_id: session.agent_id,
-                        session_id: session.session_id,
-                        message: input.to_string(),
-                        message_type: ClientChatType::Normal,
-                        channel: 0,
-                    }))
+                .send(Packet::new_chat_from_viewer(ChatFromViewer {
+                    agent_id: session.agent_id,
+                    session_id: session.session_id,
+                    message: input.to_string(),
+                    message_type: ClientChatType::Normal,
+                    channel: 0,
+                }))
                 .await
             {
                 Ok(_) => println!("chat sent: {:?}", input),

--- a/crates/chat/src/main.rs
+++ b/crates/chat/src/main.rs
@@ -3,7 +3,6 @@ use metaverse_login::models::simulator_login_protocol::Login;
 use metaverse_messages::models::chat_from_viewer::{ChatFromViewer, ClientChatType};
 use metaverse_messages::models::client_update_data::ClientUpdateData;
 use metaverse_messages::models::packet::Packet;
-use metaverse_session::models::mailbox::AllowAcks;
 use metaverse_session::session::Session;
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
@@ -111,14 +110,14 @@ fn main() {
             }
             match session
                 .mailbox
-                .send(Packet::new_chat_from_viewer(ChatFromViewer {
-                    agent_id: session.agent_id,
-                    session_id: session.session_id,
-                    message: input.to_string(),
-                    message_type: ClientChatType::Normal,
-                    channel: 0,
-                })) 
-                    //, Duration::from_secs(3), 3)
+                .send(
+                    Packet::new_chat_from_viewer(ChatFromViewer {
+                        agent_id: session.agent_id,
+                        session_id: session.session_id,
+                        message: input.to_string(),
+                        message_type: ClientChatType::Normal,
+                        channel: 0,
+                    }))
                 .await
             {
                 Ok(_) => println!("chat sent: {:?}", input),

--- a/crates/messages/src/models/chat_from_simulator.rs
+++ b/crates/messages/src/models/chat_from_simulator.rs
@@ -19,9 +19,7 @@ use uuid::Uuid;
 // Frequency: Low
 
 impl Packet {
-    pub fn new_chat_from_simulator(
-        chat_from_simulator: ChatFromSimulator,
-    ) -> Self {
+    pub fn new_chat_from_simulator(chat_from_simulator: ChatFromSimulator) -> Self {
         Packet {
             header: Header {
                 id: 139,

--- a/crates/messages/src/models/circuit_code.rs
+++ b/crates/messages/src/models/circuit_code.rs
@@ -17,7 +17,7 @@ impl Packet {
             header: Header {
                 id: 3,
                 frequency: PacketFrequency::Low,
-                reliable: false,
+                reliable: true,
                 sequence_number: 0,
                 appended_acks: false,
                 zerocoded: false,

--- a/crates/messages/src/models/packet_ack.rs
+++ b/crates/messages/src/models/packet_ack.rs
@@ -73,7 +73,6 @@ impl PacketData for PacketAck {
 
         Box::pin(async move {
             let mut queue = ack_queue.lock().unwrap();
-            println!("request ID: {:?}", queue);
             for id in packet_ids {
                 if let Some(sender) = queue.remove(&id) {
                     let _ = sender.send(());

--- a/crates/session/src/models/errors.rs
+++ b/crates/session/src/models/errors.rs
@@ -6,7 +6,7 @@ pub enum SessionError {
     CircuitCode(CircuitCodeError),
     CompleteAgentMovement(CompleteAgentMovementError),
     Login(LoginError),
-    // Add other error types here
+    AckError(AckError), // Add other error types here
 }
 
 impl SessionError {
@@ -17,14 +17,13 @@ impl SessionError {
         error.into()
     }
 }
-
 impl fmt::Display for SessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             SessionError::CircuitCode(err) => write!(f, "CircuitCodeError: {}", err),
             SessionError::Login(err) => write!(f, "LoginError: {}", err),
             SessionError::CompleteAgentMovement(err) => write!(f, "CompleteAgentMovement: {}", err),
-            // Handle other error types here
+            SessionError::AckError(err) => write!(f, "AckError: {}", err),
         }
     }
 }
@@ -35,6 +34,7 @@ impl Error for SessionError {
             SessionError::CircuitCode(err) => Some(err),
             SessionError::Login(err) => Some(err),
             SessionError::CompleteAgentMovement(err) => Some(err),
+            SessionError::AckError(err) => Some(err),
         }
     }
 }
@@ -46,7 +46,8 @@ impl SessionError {
             SessionError::Login(err) => Box::new(err.clone()) as Box<dyn Error + Send + Sync>,
             SessionError::CompleteAgentMovement(err) => {
                 Box::new(err.clone()) as Box<dyn Error + Send + Sync>
-            } // Add other error types here
+            }
+            SessionError::AckError(err) => Box::new(err.clone()) as Box<dyn Error + Send + Sync>,
         }
     }
 }
@@ -105,6 +106,28 @@ impl fmt::Display for CompleteAgentMovementError {
     }
 }
 impl Error for CompleteAgentMovementError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AckError {
+    pub message: String,
+}
+impl AckError {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl fmt::Display for AckError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for AckError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }

--- a/crates/session/tests/session.rs
+++ b/crates/session/tests/session.rs
@@ -144,16 +144,14 @@ async fn check_for_updates(stream: Arc<Mutex<Vec<ClientUpdateData>>>) {
                     ClientUpdateData::Error(error) => {
                         println!("Error received: {:?}", error);
                     }
-                    ClientUpdateData::LoginProgress(_) => {
-                        println!("Login Progress received")
+                    ClientUpdateData::LoginProgress(login) => {
+                        println!("Login Progress received {:?}", login)
                     }
                     ClientUpdateData::ChatFromSimulator(chat) => {
                         println!("Chat received {:?}", chat)
                     }
                 }
             }
-        } else {
-            println!("EMPTY");
         }
     }
 }


### PR DESCRIPTION
uses header flag to determine if something needs to be acked, and restructures ack code. What I have is slower by a lot, and causes problems with the server, as it does send duplicates sometimes. I'm going to have to spin the udp send.await into its own process somehow.