### PR TITLE
Packet docs and bugfixes

### DIFF
--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 edition = "2024"
 
 [dependencies]
+metaverse_messages = {path = "../messages/"}
 byteorder = "1.5.0"
 rgb = "0.8.50"
 uuid = "1.16.0"

--- a/crates/agent/src/avatar_appearance_handler.rs
+++ b/crates/agent/src/avatar_appearance_handler.rs
@@ -8,6 +8,19 @@ use byteorder::{LittleEndian, ReadBytesExt};
 use rgb::Rgba;
 use uuid::Uuid;
 
+pub fn parse_texture_data(bytes: &Vec<u8>) -> std::io::Result<String> {
+    let mut faces: HashMap<u32, Texture> = HashMap::new();
+    let texture_entry = Texture::from_bytes(&bytes, &mut faces)?;
+
+    println!("{:?}", faces);
+    println!("texture entry: {:?}", texture_entry);
+    Ok("hello".to_string())
+}
+
+pub fn parse_visual_param_data(_: &Vec<u8>) -> std::io::Result<String> {
+    Ok("visual param".to_string())
+}
+
 #[derive(Debug, Clone)]
 pub struct Texture {
     pub texture_id: Uuid,
@@ -140,19 +153,6 @@ pub struct AppearanceData {
     pub appearance_version: u8,
     pub current_outfit_folder_version: f32,
     pub flags: u32,
-}
-
-pub fn parse_texture_data(bytes: &Vec<u8>) -> std::io::Result<String> {
-    let mut faces: HashMap<u32, Texture> = HashMap::new();
-    let texture_entry = Texture::from_bytes(&bytes, &mut faces)?;
-
-    println!("{:?}", faces);
-    println!("texture entry: {:?}", texture_entry);
-    Ok("hello".to_string())
-}
-
-pub fn parse_visual_param_data(bytes: &Vec<u8>) -> std::io::Result<String> {
-    Ok("visual param".to_string())
 }
 
 fn read_face_bitfield(cursor: &mut Cursor<&[u8]>) -> std::io::Result<(u32, u32)> {

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod avatar_appearance_handler;
+
+pub mod object_update_handler;

--- a/crates/agent/src/object_update_handler.rs
+++ b/crates/agent/src/object_update_handler.rs
@@ -1,0 +1,6 @@
+use metaverse_messages::core::object_update::ObjectUpdate;
+
+pub fn handle_object_update(data: &ObjectUpdate) -> std::io::Result<String> {
+    println!("{:?}",data);
+    Ok("aaa".to_string())
+}

--- a/crates/messages/src/agent/mod.rs
+++ b/crates/messages/src/agent/mod.rs
@@ -55,23 +55,23 @@ pub mod agent_update;
 pub mod coarse_location_update;
 
 /// # Avatar Appearance
-/// <https://wiki.secondlife.com/wiki/AvatarAppearance> 
+/// <https://wiki.secondlife.com/wiki/AvatarAppearance>
 ///
-/// This packet is used to update the appearane of a user's avatar. 
-/// Contains textures and VisualParams for the avatar 
+/// This packet is used to update the appearane of a user's avatar.
+/// Contains textures and VisualParams for the avatar
 ///
 /// ## Header
 /// | Avatar Appearance  |       |                |                   |                     |
 /// |--------------|-------------|----------------|-------------------|---------------------|
 /// | Packet Header| id:158      | reliable: false| zerocoded: false  | frequency: Low      |
 ///
-/// ## Packet Structure 
+/// ## Packet Structure
 /// |Avatar Appearance ||||
 /// |--------------|----------|--------------------|----------------|
 /// | id           | 16 bytes | [Uuid](uuid::Uuid) | ID of the user |  
-/// | is_trial     | 1 byte   | [bool]             | Is the user a trial user| 
+/// | is_trial     | 1 byte   | [bool]             | Is the user a trial user|
 /// | texture_len  | 2 bytes  | [u16]              | length of the texture data block |
-/// | texture_data | variable bytes |              | Texture data for each face | 
-/// | v_param_len  | 1 byte   | [u8]               | length of visual param block | 
+/// | texture_data | variable bytes |              | Texture data for each face |
+/// | v_param_len  | 1 byte   | [u8]               | length of visual param block |
 /// | visual_param_data | variable byes |          | Bytes containing the visual param data |
 pub mod avatar_appearance;

--- a/crates/messages/src/agent/mod.rs
+++ b/crates/messages/src/agent/mod.rs
@@ -54,4 +54,24 @@ pub mod agent_update;
 /// | Prey                   | 2 bytes          | [i16]         | Index of who you are following in the list|
 pub mod coarse_location_update;
 
+/// # Avatar Appearance
+/// <https://wiki.secondlife.com/wiki/AvatarAppearance> 
+///
+/// This packet is used to update the appearane of a user's avatar. 
+/// Contains textures and VisualParams for the avatar 
+///
+/// ## Header
+/// | Avatar Appearance  |       |                |                   |                     |
+/// |--------------|-------------|----------------|-------------------|---------------------|
+/// | Packet Header| id:158      | reliable: false| zerocoded: false  | frequency: Low      |
+///
+/// ## Packet Structure 
+/// |Avatar Appearance ||||
+/// |--------------|----------|--------------------|----------------|
+/// | id           | 16 bytes | [Uuid](uuid::Uuid) | ID of the user |  
+/// | is_trial     | 1 byte   | [bool]             | Is the user a trial user| 
+/// | texture_len  | 2 bytes  | [u16]              | length of the texture data block |
+/// | texture_data | variable bytes |              | Texture data for each face | 
+/// | v_param_len  | 1 byte   | [u8]               | length of visual param block | 
+/// | visual_param_data | variable byes |          | Bytes containing the visual param data |
 pub mod avatar_appearance;

--- a/crates/messages/src/core/mod.rs
+++ b/crates/messages/src/core/mod.rs
@@ -127,4 +127,193 @@ pub mod start_ping_check;
 /// | PingID | 1 byte | [u8] | the value received during StartPingCheck. Lets server know which ping was completed. |
 pub mod complete_ping_check;
 
+/// # Object Update
+/// <https://wiki.secondlife.com/wiki/ObjectUpdate>
+///
+/// Sent by the server to update an object. Handles avatars, clothes, furniture, trees, grass, etc.
+/// This notifies the viewer of almost everything. While not being a very large packet, nearly
+/// every byte is used individually, and there aren't many multi-byte data structures to read.
+///
+/// ## Header
+/// | ObjectUpdate |             |                |                  |                     |
+/// |--------------|-------------|----------------|------------------|---------------------|
+/// | Packet Header| id:12       | reliable: false| zerocoded: true  |     frequency: High |
+///
+/// ## Packet Structure
+/// | ObjectUpdate ||||
+/// |---------------|---------|-------|--------------------------------------|
+/// | region_x      | 4 bytes | [u32] | Global x coordinate of the simulator |
+/// | region_y      | 4 bytes | [u32] | Global y coordinate of the simulator |
+/// | time_dilation | 2 bytes | [u16] | The current lag from the server. Used by physics simulations to keep up with real time. |
+/// | id            | 4 bytes | [u32] | region local ID. used for most operations in lieu of the object's full UUID. |
+/// | state         | 1 byte  | [u8]  | Unused except by grass to determine grass species |
+/// | full_id       | 16 bytes| [Uuid](uuid::Uuid) | The full UUID of the object |
+/// | crc           | 4 bytes | [u32] | CRC values. Not currently checked against anything. |
+/// | pcode         | 1 byte  | [u8]  | Type of object represented by the packet. Avatar, grass, tree, etc |
+/// | material      | 1 byte  | [u8]  | Type of material the object is made of. Wood, plastic, flesh, etc |
+/// | click_action  | 1 byte  | [u8]  | The default action taken when the object is clicked. Open, sit, etc |
+/// | scale_x       | 4 bytes | [u32] | The x value of the object's scale |
+/// | scale_y       | 4 bytes | [u32] | The y value of the object's scale |
+/// | scale_z       | 4 bytes | [u32] | the z value of the object's scale |
+/// | data_length   | 1 byte  | [u8]  | Number of bytes to read for the object_data |
+/// | [object_data](#object-data) | variable bytes | | Velocity, position and rotation values|
+/// | parent_id     | 4 bytes | [u32] | Local ID of an object this object is a child of. 0 if none is present. |
+/// | update_flags  | 4 bytes | [u32] | Gives various pieces of information to the viewer, like empty inventory or scripted |
+/// | [Primitive geometry](#primitive-geometry) | 23 bytes | | Data for the viewer to draw primitive objects |
+/// | texture_length| 1 byte  | [u8]  |  Number of bytes to read for the texture_entry data |
+/// | texture_entry | variable bytes || Full property list of each object's face, including textures and colors. |
+/// | anim_length   | 1 byte  | [u8]  | Number of bytes to read for the texture_anim_data |
+/// | texture_anim  | variable bytes || Properties to set up texture animations of the face of the object |
+/// | name_length   | 2 bytes | [u16] | Number of bytes to read for the name value. Big-endian |
+/// | name_value    | variable bytes || Name value pairs specific to the object. Used for avatar names. |
+/// | data_length   | 2 bytes | [u16] | Number of bytes to read for the generic appended data |
+/// | data          | variable bytes || Generic appended data |
+/// | text_length   | 1 byte  | [u8]  | Number of bytes to read for the text data |
+/// | text          | variable bytes || Text that hovers over the object |
+/// | text_color_r  | 1 byte  | [u8]  | Hover text color's red value |
+/// | text_color_g  | 1 byte  | [u8]  | Hover text color's green value |
+/// | text_color_b  | 1 byte  | [u8]  | Hover text color's blue value |
+/// | text_color_a  | 1 byte  | [u8]  | Hover text color's alpha value |
+/// | media_length  | 1 byte  | [u8]  | Number of bytes to read for the media URL |
+/// | media_url     | variable bytes || URL for any media attached to the object. Will always be a webpage. |
+/// | particle_len  | 1 byte  | [u8]  | Number of bytes to read for the particle system data |
+/// | particle_system | variable bytes || Attached particles for the object |
+/// | extra_len     | 1 byte  | [u8]  | Number of bytes to read for the extra parameters |
+/// | extra_params  | variable bytes || Data related to flexible primitives, sculpt data or light |
+/// |[sound](#sound)| 41 bytes | | Data for looping sound the object emits |
+/// | joint_type    | 1 byte  | [u8]  | Type of joint the object uses. Legacy.|
+/// | joint_pivot_x | 4 bytes | [f32] | x location of pivot. Legacy. |
+/// | joint_pivot_y | 4 bytes | [f32] | y location of pivot. Legacy. |
+/// | joint_pivot_z | 4 bytes | [f32] | z location of pivot. Legacy. |
+/// | joint_axis_or_anchor_x | 4 bytes | [f32] | x location of the offset or axis. Legacy |
+/// | joint_axis_or_anchor_y | 4 bytes | [f32] | y location of the offset or axis. Legacy |
+/// | joint_axis_or_anchor_z | 4 bytes | [f32] | z location of the offset or axis. Legacy |
+///
+/// ## Object Data
+/// ObjectData is read differently based on the length of the objectadata field.
+/// There are high precision updates, medium precision updates and low precision updates,
+/// which read different sized integers. High precision updates use the largest amount of
+/// bytes, using f32s for its value, and low precision updates use the smallest amount of bytes,
+/// using u8s for its value.
+///
+/// ### High Precision Update with Foot Collision Plane
+///
+/// | Object Data       | 76 bytes|||
+/// |-------------------|---------|-------|--------------------------------------|
+/// | collision_plane_a | 4 bytes | [f32] | a corner of the collision plane      |
+/// | collision_plane_b | 4 bytes | [f32] | b corner of the collision plane      |
+/// | collision_plane_c | 4 bytes | [f32] | c corner of the collision plane      |
+/// | collision_plane_d | 4 bytes | [f32] | d corner of the collision plane      |
+/// | [High Precision Update](#high-precision-update) |||                        |
+///
+/// The remaining 60 bytes are used to create a high precision update. However, the last 3 f32s are not read.
+/// the angular velocity when receiving a 76 byte object data will always be 0.0, 0.0, 0.0.
+///
+/// ### High Precision Update
+/// | Object Data       | 60 bytes|||
+/// |-------------------|---------|-------|--------------------------------------|
+/// | position_x        | 4 bytes | [f32] | the x position of the object         |
+/// | position_y        | 4 bytes | [f32] | the y position of the object         |
+/// | position_z        | 4 bytes | [f32] | the z position of the object         |
+/// | velocity_x        | 4 bytes | [f32] | the x velocity of the object         |
+/// | velocity_y        | 4 bytes | [f32] | the y velocity of the object         |
+/// | velocity_z        | 4 bytes | [f32] | the z velocity of the object         |
+/// | acceleration_x    | 4 bytes | [f32] | the x acceleration of the object     |
+/// | acceleration_y    | 4 bytes | [f32] | the y acceleration of the object     |
+/// | acceleration_z    | 4 bytes | [f32] | the z acceleration of the object     |
+/// | rotation_x        | 4 bytes | [f32] | the x rotation of the object as a quaternion |
+/// | rotation_y        | 4 bytes | [f32] | the y rotation of the object as a quaternion |
+/// | rotation_z        | 4 bytes | [f32] | the z rotation of the object as a quaternion |
+/// | rotation_w        | 4 bytes | [f32] | the w rotation of the object as a quaternion |
+/// | angular_velocity_x| 4 bytes | [f32] | the x angular velocity of the object |
+/// | angular_velocity_y| 4 bytes | [f32] | the y angular velocity of the object |
+/// | angular_velocity_z| 4 bytes | [f32] | the z angular velocity of the object |
+///
+/// ### Medium Precision Update With Foot Collision Plane
+/// | Object Data       | 48 bytes|||
+/// |-------------------|---------|-------|--------------------------------------|
+/// | collision_plane_a | 4 bytes | [f32] | a corner of the collision plane      |
+/// | collision_plane_b | 4 bytes | [f32] | b corner of the collision plane      |
+/// | collision_plane_c | 4 bytes | [f32] | c corner of the collision plane      |
+/// | collision_plane_d | 4 bytes | [f32] | d corner of the collision plane      |
+/// | [Medium Precision Update](#medium-precision-update) |   |       |                                      |
+///
+///
+/// ### Medium Precision Update
+/// | Object Data       | 32 bytes|||
+/// |-------------------|---------|-------|--------------------------------------|
+/// | position_x        | 2 bytes | [u16] | the x position of the object         |
+/// | position_y        | 2 bytes | [u16] | the y position of the object         |
+/// | position_z        | 2 bytes | [u16] | the z position of the object         |
+/// | velocity_x        | 2 bytes | [u16] | the x velocity of the object         |
+/// | velocity_y        | 2 bytes | [u16] | the y velocity of the object         |
+/// | velocity_z        | 2 bytes | [u16] | the z velocity of the object         |
+/// | acceleration_x    | 2 bytes | [u16] | the x acceleration of the object     |
+/// | acceleration_y    | 2 bytes | [u16] | the y acceleration of the object     |
+/// | acceleration_z    | 2 bytes | [u16] | the z acceleration of the object     |
+/// | rotation_x        | 2 bytes | [u16] | the x rotation of the object as a quaternion |
+/// | rotation_y        | 2 bytes | [u16] | the y rotation of the object as a quaternion |
+/// | rotation_z        | 2 bytes | [u16] | the z rotation of the object as a quaternion |
+/// | rotation_w        | 2 bytes | [u16] | the w rotation of the object as a quaternion |
+/// | angular_velocity_x| 2 bytes | [u16] | the x angular velocity of the object |
+/// | angular_velocity_y| 2 bytes | [u16] | the y angular velocity of the object |
+/// | angular_velocity_z| 2 bytes | [u16] | the z angular velocity of the object |
+///
+/// ### Low Precision Update
+/// | Object Data       | 16 bytes|||
+/// |-------------------|---------|-------|--------------------------------------|
+/// | position_x        | 1 byte  | [u8] | the x position of the object         |
+/// | position_y        | 1 byte  | [u8] | the y position of the object         |
+/// | position_z        | 1 byte  | [u8] | the z position of the object         |
+/// | velocity_x        | 1 byte  | [u8] | the x velocity of the object         |
+/// | velocity_y        | 1 byte  | [u8] | the y velocity of the object         |
+/// | velocity_z        | 1 byte  | [u8] | the z velocity of the object         |
+/// | acceleration_x    | 1 byte  | [u8] | the x acceleration of the object     |
+/// | acceleration_y    | 1 byte  | [u8] | the y acceleration of the object     |
+/// | acceleration_z    | 1 byte  | [u8] | the z acceleration of the object     |
+/// | rotation_x        | 1 byte  | [u8] | the x rotation of the object as a quaternion |
+/// | rotation_y        | 1 byte  | [u8] | the y rotation of the object as a quaternion |
+/// | rotation_z        | 1 byte  | [u8] | the z rotation of the object as a quaternion |
+/// | rotation_w        | 1 byte  | [u8] | the w rotation of the object as a quaternion |
+/// | angular_velocity_x| 1 byte  | [u8] | the x angular velocity of the object |
+/// | angular_velocity_y| 1 byte  | [u8] | the y angular velocity of the object |
+/// | angular_velocity_z| 1 byte  | [u8] | the z angular velocity of the object |
+
+///
+/// ## Primitive Geometry
+///
+/// ObjectData values to do with drawing primitive geometry in the scene
+/// | Primitive Geometry ||||
+/// |---------------|---------|-------|--------------------------------------|
+/// | path_curve    | 1 byte  | [u8]  | The type of path the shape follows. 0x00 is a Line, 0x10 is a circle, etc |
+/// | path_begin    | 2 bytes | [u16] | Start point of the path. Controls how much of the extrusion is used. |
+/// | path_end      | 2 bytes | [u16] | end point of the path |
+/// | path_scale_x  | 1 byte  | [u8]  | x scaling at the end of the extrusion. `128 means no scaling.|
+/// | path_scale_y  | 1 byte  | [u8]  | y scaling at the end of the extrusion. `128 means no scaling.|
+/// | path_scale_z  | 1 byte  | [u8]  | z scaling at the end of the extrusion. `128 means no scaling.|
+/// | path_shear_x  | 1 byte  | [u8]  | x axis shear. 128 is no shear. |
+/// | path_shear_y  | 1 byte  | [u8]  | y axis shear. 128 is no shear. |
+/// | path_twist_end| 1 byte  | [i8]  | Twist applied at the end of the path. `128 is no twist.  |
+/// | path_twist_begin| 1 byte  | [i8]  | Twist applied at the beginning of the path. `128 is no twist.  |
+/// | path_radius_offset | 1 byte | [i8] | How much the shape's path moves away from the axis. 128 is no offset. |
+/// | path_taper_y  | 1 byte  | [i8]  | tapers the shape from thick to thin on y axis. 128 is no taper. |
+/// | path_taper_x  | 1 byte  | [i8]  | tapers the shape from thick to thin on x axis. 128 is no taper. |
+/// | path_revolutions| 1 byte | [u8] | The number of times the shape revolves around its path. 128 is one revolution. |
+/// | path_skew     | 1 byte  | [i8]  | Skews the shape along its path. 128 is no skew. |
+/// | profile_curve | 1 byte  | [u8]  | What the shape looks like from profile. 0x00 is circular, 0x01 is square, etc |
+/// | profile_begin | 2 bytes | [u16] | The start point of the profile. Controls how much extrusion is used horizontally. | \
+/// | profile_end   | 2 bytes | [u16] | The end point of the profile horizontally |
+/// | profile_hollow| 4 bytes | [f32] | Makes a hollow in the shape. EG. a hollow cylinder becomes a tube. |
+///
+///
+/// ## Sound
+///
+/// ObjectData values to do with sounds the object may emit
+/// | Sound ||||
+/// |---------------|---------|-------|--------------------------------------|
+/// | sound_id      | 16 bytes| [Uuid](uuid::Uuid) | The UUID of attached looped sounds |
+/// | owner_id      | 16 bytes| [Uuid](uuid::Uuid) | UUID of the owner object. Null if there is no sound attached. |
+/// | gain          | 4 bytes | [f32] | The gain of the attached sound |
+/// | flags         | 1 byte  | [u8]  | Flags related to attached sound |
+/// | radius        | 4 bytes | [f32] | Radius from the center of the object that the sound is audible from |
 pub mod object_update;

--- a/crates/messages/tests/object_update.rs
+++ b/crates/messages/tests/object_update.rs
@@ -11,7 +11,7 @@ const PACKET: [u8; 169] = [
     32, 82, 87, 32, 83, 86, 32, 0, 77,
 ];
 
-const FAILED_PACKET: [u8; 160] = [
+const PACKET2: [u8; 160] = [
     192, 0, 0, 0, 18, 0, 12, 0, 1, 66, 39, 0, 2, 162, 40, 0, 1, 255, 255, 1, 0, 1, 88, 126, 29, 0,
     1, 254, 189, 105, 110, 131, 188, 70, 110, 171, 72, 99, 132, 234, 103, 190, 207, 134, 110, 176,
     52, 9, 3, 0, 1, 59, 168, 95, 64, 59, 168, 95, 64, 51, 55, 191, 63, 60, 78, 11, 16, 192, 97,
@@ -22,15 +22,39 @@ const FAILED_PACKET: [u8; 160] = [
     32, 0, 101,
 ];
 
+const MORE_PACKET: [u8; 172] = [
+    224, 0, 0, 0, 23, 0, 12, 0, 1, 66, 39, 0, 2, 162, 40, 0, 1, 255, 255, 1, 32, 89, 126, 29, 0, 1,
+    186, 190, 2, 243, 77, 219, 64, 74, 143, 97, 248, 182, 3, 214, 214, 63, 156, 209, 87, 54, 9, 3,
+    0, 2, 192, 188, 60, 0, 1, 38, 148, 63, 224, 226, 160, 63, 60, 57, 180, 236, 66, 213, 88, 2, 67,
+    231, 204, 12, 66, 0, 52, 208, 0, 1, 2, 0, 1, 16, 1, 0, 4, 100, 100, 0, 15, 81, 0, 1, 87, 72,
+    222, 204, 246, 41, 70, 28, 154, 54, 163, 90, 34, 31, 226, 31, 20, 55, 132, 88, 115, 227, 146,
+    70, 41, 165, 172, 251, 125, 184, 162, 66, 22, 0, 1, 128, 128, 128, 0, 4, 128, 63, 0, 3, 128,
+    63, 0, 10, 32, 0, 3, 26, 0, 30, 23, 1, 32, 0, 1, 16, 0, 3, 127, 127, 127, 255, 0, 2, 160, 64,
+    0, 4, 10, 215, 35, 60, 0, 66,
+];
+
 const DEFAULT_USER_ID: Uuid = uuid!("9dc18bb1044f4c68906b2cb608b2e197");
+const TEST_FULL_ID: Uuid = uuid!("febd696e-83bc-466e-ab48-6384ea67becf");
 #[test]
 pub fn test_object_update() {
-    //let object_update = Packet::from_bytes(&PACKET).unwrap();
-
-    let object_update = Packet::from_bytes(&FAILED_PACKET).unwrap();
+   // let object_update = Packet::from_bytes(&PACKET).unwrap();
+   // match object_update.body {
+   //     PacketType::ObjectUpdate(object) => {
+   //         assert_eq!(object.full_id, DEFAULT_USER_ID)
+   //     }
+   //     _ => assert!(false),
+   // }
+   // let object_update = Packet::from_bytes(&PACKET2).unwrap();
+   // match object_update.body {
+   //     PacketType::ObjectUpdate(object) => {
+   //         assert_eq!(object.full_id, TEST_FULL_ID)
+   //     }
+   //     _ => assert!(false),
+   // }
+    let object_update = Packet::from_bytes(&MORE_PACKET).unwrap();
     match object_update.body {
         PacketType::ObjectUpdate(object) => {
-            assert_eq!(object.full_id, DEFAULT_USER_ID)
+            assert_eq!(object.full_id, TEST_FULL_ID)
         }
         _ => assert!(false),
     }

--- a/crates/messages/tests/object_update.rs
+++ b/crates/messages/tests/object_update.rs
@@ -37,20 +37,20 @@ const DEFAULT_USER_ID: Uuid = uuid!("9dc18bb1044f4c68906b2cb608b2e197");
 const TEST_FULL_ID: Uuid = uuid!("febd696e-83bc-466e-ab48-6384ea67becf");
 #[test]
 pub fn test_object_update() {
-   // let object_update = Packet::from_bytes(&PACKET).unwrap();
-   // match object_update.body {
-   //     PacketType::ObjectUpdate(object) => {
-   //         assert_eq!(object.full_id, DEFAULT_USER_ID)
-   //     }
-   //     _ => assert!(false),
-   // }
-   // let object_update = Packet::from_bytes(&PACKET2).unwrap();
-   // match object_update.body {
-   //     PacketType::ObjectUpdate(object) => {
-   //         assert_eq!(object.full_id, TEST_FULL_ID)
-   //     }
-   //     _ => assert!(false),
-   // }
+    // let object_update = Packet::from_bytes(&PACKET).unwrap();
+    // match object_update.body {
+    //     PacketType::ObjectUpdate(object) => {
+    //         assert_eq!(object.full_id, DEFAULT_USER_ID)
+    //     }
+    //     _ => assert!(false),
+    // }
+    // let object_update = Packet::from_bytes(&PACKET2).unwrap();
+    // match object_update.body {
+    //     PacketType::ObjectUpdate(object) => {
+    //         assert_eq!(object.full_id, TEST_FULL_ID)
+    //     }
+    //     _ => assert!(false),
+    // }
     let object_update = Packet::from_bytes(&MORE_PACKET).unwrap();
     match object_update.body {
         PacketType::ObjectUpdate(object) => {

--- a/crates/session/src/core.rs
+++ b/crates/session/src/core.rs
@@ -5,6 +5,7 @@ use log::{error, info, warn};
 
 use metaverse_agent::avatar_appearance_handler::parse_texture_data;
 use metaverse_agent::avatar_appearance_handler::parse_visual_param_data;
+use metaverse_agent::object_update_handler::handle_object_update;
 #[cfg(feature = "environment")]
 use metaverse_environment::layer_handler::{PatchData, PatchLayer, parse_layer_data};
 
@@ -236,7 +237,9 @@ impl Mailbox {
                             }
                             ObjectType::Avatar => {
                                 #[cfg(feature = "agent")]
-                                println!("AVATAR");
+                                if let Err(e) = handle_object_update(data){
+                                    warn!("Error handling avatar {:?}", e);
+                                };
                             }
                         },
                         #[cfg(feature = "environment")]

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -8,7 +8,23 @@ resolver = "2"
 metaverse_session = {path = "../session/"}
 metaverse_messages = {path = "../messages/"}
 
-bevy = "0.16"
+#disable sound for bevy
+bevy = { version = "0.16", default-features = false, features = [
+    "bevy_winit",
+    "bevy_render",
+    "bevy_pbr",
+    "bevy_gltf",
+    "bevy_ui",
+    "bevy_text",
+    "bevy_state",
+    "bevy_picking",
+    "bevy_window",
+    "bevy_core_pipeline",
+    "multi_threaded",
+    "bevy_log",
+    "tonemapping_luts"
+]}
+
 bevy_egui = "0.34.1"
 bevy_panorbit_camera = "0.26.0"
 
@@ -25,6 +41,7 @@ serde_json = "1.0"
 portpicker = "0.1.1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 dirs = "6.0.0"
+log = "0.4.27"
 [dependencies.uuid]
 version = "1.16.0"
 features = [

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -5,6 +5,8 @@ mod login;
 
 use actix_rt::System;
 use bevy::asset::UnapprovedPathMode;
+use bevy::{prelude::*, tasks::AsyncComputeTaskPool};
+use bevy_egui::{EguiContexts, EguiPlugin, egui};
 use bevy_panorbit_camera::PanOrbitCameraPlugin;
 use chat::chat_screen;
 use crossbeam_channel::unbounded;
@@ -14,20 +16,18 @@ use environment::{
 };
 use keyring::Entry;
 use loading::loading_screen;
+use log::{error, info, warn};
 use login::login_screen;
 use metaverse_messages::agent::coarse_location_update::CoarseLocationUpdate;
 use metaverse_messages::login::login_errors::LoginError;
 use metaverse_messages::login::login_response::LoginResponse;
 use metaverse_messages::packet::packet_types::PacketType;
 use metaverse_messages::ui::errors::SessionError;
+use metaverse_session::initialize::initialize;
 use metaverse_session::ui_subscriber::listen_for_core_events;
 use portpicker::pick_unused_port;
 use std::fs::{self, create_dir_all};
 use std::path::PathBuf;
-
-use bevy::{prelude::*, tasks::AsyncComputeTaskPool};
-use bevy_egui::{EguiContexts, EguiPlugin, egui};
-use metaverse_session::initialize::initialize;
 
 #[derive(Resource)]
 struct Sockets {


### PR DESCRIPTION
Adds docs for ObjectUpdate and AgentAppearance packets, and sets Bevy requirements to the bare minimum 