### PR TITLE
Add prereqs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is a debug UI. Written in bevy and bevy-egui, it is not expected to get ver
 
 ## Getting Started
 
-Prerequisite Packages (Fedora names, yours may vary):
+Prerequisite Packages:
 * `rust`
 * `cargo`
 * `openssl-devel`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Prerequisite Packages (Fedora names, yours may vary):
 * `openssl-devel`
 * `alsa-lib-devel`
 * `rust-libudev-devel`
+* `rust-libdbus-devel`
 
 ### Building
 ``cargo run``

--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ Provides a straightforward way of handling incoming Layer Data information being
 ### Ui
 This is a debug UI. Written in bevy and bevy-egui, it is not expected to get very polished. The more user-friendly UI can be found at [benthic_viewer](https://github.com/benthic-mmo/benthic_viewer). 
 
-## Getting Started 
+## Getting Started
+
+Prerequisite Packages (Fedora names, yours may vary):
+* `rust`
+* `cargo`
+* `openssl-devel`
+* `alsa-lib-devel`
+* `rust-libudev-devel`
+
+### Building
 ``cargo run``
 Will run the debug UI.
 ``cargo test`` 


### PR DESCRIPTION
Quick README update!

Starting from an almost fresh Fedora instance, I needed to `yum install` a handful of prerequisites before I was able to build successfully.  I've listed 'em out here.